### PR TITLE
Fix installer not finding ooe.sh

### DIFF
--- a/bin/install_automation.sh
+++ b/bin/install_automation.sh
@@ -11,11 +11,8 @@ set +x
 # bash
 # core-utils
 # curl
-# find-utils
 # git
 # install
-# jq
-# sed
 
 AUTOMATION_REPO_URL=${AUTOMATION_REPO_URL:-https://github.com/containers/automation.git}
 AUTOMATION_REPO_BRANCH=${AUTOMATION_REPO_BRANCH:-master}
@@ -26,8 +23,8 @@ AUTOMATION_VERSION="$1"
 shift || true  # ignore if no more args
 # Set non-zero to enable
 DEBUG=${DEBUG:-0}
-# Save a bit of typin
-OOE=$(realpath $(dirname "${BASH_SOURCE[0]}")/../common/bin/ooe.sh)
+# Save some output eyestrain (if script can be found)
+OOE=$(realpath $(dirname "${BASH_SOURCE[0]}")/../common/bin/ooe.sh 2>/dev/null || echo "")
 # Sentinel value representing whatever version is present in the local repository
 MAGIC_LOCAL_VERSION='0.0.0'
 # Needed for unit-testing

--- a/common/test/testbin-install_automation.sh
+++ b/common/test/testbin-install_automation.sh
@@ -72,11 +72,10 @@ test_cmd \
     0 "PATH ==> .+:$INSTALL_PREFIX/automation/bin" \
     load_example_environment
 
-# TODO: Enable when upstream release is available
-#test_cmd \
-#    "The installed installer, can update itself to the latest upstream version" \
-#    0 "Installation complete for v[0-9]+\.[0-9]+\.[0-9]+" \
-#    execute_in_example_environment $SUBJ_FILENAME latest
+test_cmd \
+    "The installed installer, can update itself to the latest upstream version" \
+    0 "Installation complete for v[0-9]+\.[0-9]+\.[0-9]+" \
+    execute_in_example_environment $SUBJ_FILENAME latest
 
 # Must be last call
 exit_with_status


### PR DESCRIPTION
It should be possible to execute the install script stand-alone, from
outside of the repository.  However, this could fail if an optional
component cannot be located.  Update the installer code to treat
this component as optional, ignoring errors if any.

Signed-off-by: Chris Evich <cevich@redhat.com>