### PR TITLE
Add retrieval of task and build id values

### DIFF
--- a/.github/workflows/cirrus-ci_retrospective.yml
+++ b/.github/workflows/cirrus-ci_retrospective.yml
@@ -43,6 +43,7 @@ jobs:
               shell: bash
               run: |
                   prn=$(jq --raw-output '.[] | select(.name == "cirrus-ci/success") | .build.pullRequest' ./cirrus-ci_retrospective.json)
+                  tid=$(jq --raw-output '.[] | select(.name == "cirrus-ci/success") | .id' ./cirrus-ci_retrospective.json)
                   sha=$(jq --raw-output '.[] | select(.name == "cirrus-ci/success") | .build.changeIdInRepo' ./cirrus-ci_retrospective.json)
                   if [[ -n "$prn" ]] && [[ "$prn" != "null" ]] && [[ $prn -gt 0 ]] && [[ -n "$sha" ]]; then
                       printf "\n::set-output name=was_pr::true\n"
@@ -51,6 +52,7 @@ jobs:
                       printf "\n::set-output name=was_pr::false\n"
                       printf "\n::set-output name=prn::null\n"
                   fi
+                  printf "\n::set-output name=tid::%s\n" "$tid"
                   printf "\n::set-output name=sha::%s\n" "$sha"
 
             # In case there was a problem, provide details about what might have gone wrong.
@@ -64,6 +66,7 @@ jobs:
                   echo "Analysis Result:"
                   echo "Was PR: ${{ steps.retro.outputs.was_pr }}"
                   echo "PR Number: ${{ steps.retro.outputs.prn }}"
+                  echo "Task ID was: ${{ steps.retro.outputs.tid }}"
                   echo "SHA: ${{ steps.retro.outputs.sha }}"
 
             # Provide feedback to PR in the form of a comment, referncing this run.

--- a/cirrus-ci_retrospective/README.md
+++ b/cirrus-ci_retrospective/README.md
@@ -91,8 +91,10 @@ containing multiple `tasks`.
 
 ```json
     {
+        id: "1234567890",
         ...cut...
         "build": {
+            "id": "0987654321"
             "changeIdInRepo": "679085b3f2b40797fedb60d02066b3cbc592ae4e",
             "branch": "pull/34",
             "pullRequest": 34,
@@ -106,10 +108,12 @@ containing multiple `tasks`.
 
 ```json
     {
+        id: "something",
         ...cut...
         "status": "PAUSED",
         "automaticReRun": false,
         "build": {
+            "id": "otherthing"
             "changeIdInRepo": "679085b3f2b40797fedb60d02066b3cbc592ae4e",
             "branch": "pull/34",
             "pullRequest": 34,
@@ -130,6 +134,7 @@ conclude until the manual task is triggered and completes (pass, fail, or other)
     {
         ...cut...
         "build": {
+            "id": "foobarbaz"
             "changeIdInRepo": "232bae5d8ffb6082393e7543e4e53f978152f98a",
             "branch": "master",
             "pullRequest": null,
@@ -143,6 +148,7 @@ conclude until the manual task is triggered and completes (pass, fail, or other)
 
 ```json
     {
+        id: "1234567890",
         ...cut...
         "build": {
             ...cut...

--- a/cirrus-ci_retrospective/bin/cirrus-ci_retrospective.sh
+++ b/cirrus-ci_retrospective/bin/cirrus-ci_retrospective.sh
@@ -113,10 +113,11 @@ do
         "$CCI_URL" \
         "{
           task(id: $task_id) {
+            id
             name
             status
             automaticReRun
-            build {changeIdInRepo branch pullRequest status repository {
+            build {id changeIdInRepo branch pullRequest status repository {
                 owner name cloneUrl masterBranch
               }
             }


### PR DESCRIPTION
Both of these values are handy to have, and in some cases required.  For
example, the task ID is needed for triggering a re-run via the Cirrus-CI
GraphQL API.

Signed-off-by: Chris Evich <cevich@redhat.com>