### PR TITLE
Symlink bins during install

### DIFF
--- a/cirrus-ci_retrospective/.install.sh
+++ b/cirrus-ci_retrospective/.install.sh
@@ -6,14 +6,13 @@
 source "$AUTOMATION_LIB_PATH/anchors.sh"
 source "$AUTOMATION_LIB_PATH/console_output.sh"
 
-INSTALL_PREFIX=$(realpath $AUTOMATION_LIB_PATH/../)
 # Assume the directory this script is in, represents what is being installed
 INSTALL_NAME=$(basename $(dirname ${BASH_SOURCE[0]}))
 AUTOMATION_VERSION=$(automation_version)
 [[ -n "$AUTOMATION_VERSION" ]] || \
     die "Could not determine version of common automation libs, was 'install_automation.sh' successful?"
 
-echo "Installing $INSTALL_NAME version $(automation_version) into $INSTALL_PREFIX"
+echo "Installing $INSTALL_NAME version $(automation_version) into $INSTALL_PREFIX/share/automation"
 
 unset INST_PERM_ARG
 if [[ $UID -eq 0 ]]; then
@@ -21,8 +20,17 @@ if [[ $UID -eq 0 ]]; then
 fi
 
 cd $(dirname $(realpath "${BASH_SOURCE[0]}"))
-install -v $INST_PERM_ARG -D -t "$INSTALL_PREFIX/bin" ./bin/*
-install -v $INST_PERM_ARG -D -t "$INSTALL_PREFIX/lib" ./lib/*
+install -v $INST_PERM_ARG -D -t "$INSTALL_PREFIX/share/automation/bin" ./bin/*
+install -v $INST_PERM_ARG -D -t "$INSTALL_PREFIX/share/automation/lib" ./lib/*
+
+cat << EOF > "$INSTALL_PREFIX/bin/${INSTALL_NAME}.sh"
+#!/bin/bash
+# Created by 'install_automation.sh $INSTALL_NAME' on $(date --iso-8601=minutes)
+# Automation installer version $AUTOMATION_VERSION
+set -e
+source "$AUTOMATION_LIB_PATH/environment"
+exec "$INSTALL_PREFIX/share/automation/bin/${INSTALL_NAME}.sh"
+EOF
 
 # Needed for installer testing
 echo "Successfully installed $INSTALL_NAME"

--- a/cirrus-ci_retrospective/Dockerfile
+++ b/cirrus-ci_retrospective/Dockerfile
@@ -8,11 +8,11 @@ ARG INSTALL_AUTOMATION_VERSION=latest
 ARG INSTALL_AUTOMATION_URI=https://raw.githubusercontent.com/containers/automation/master/bin/install_automation.sh
 ADD / /usr/src/automation
 RUN if [[ "$INSTALL_AUTOMATION_VERSION" == "0.0.0" ]]; then \
-        env INSTALL_PREFIX=/usr/share \
+        env INSTALL_PREFIX=/usr \
         /usr/src/automation/bin/install_automation.sh 0.0.0 cirrus-ci_retrospective; \
     else \
         curl --silent --show-error --location \
-        --url "$INSTALL_AUTOMATION_URI" | env INSTALL_PREFIX=/usr/share \
+        --url "$INSTALL_AUTOMATION_URI" | env INSTALL_PREFIX=/usr \
             /bin/bash -s - "$INSTALL_AUTOMATION_VERSION" cirrus-ci_retrospective; \
     fi
 # Required environment variables
@@ -24,4 +24,4 @@ ENV AUTOMATION_LIB_PATH="" \
 # Optional (recommended) environment variables
 ENV OUTPUT_JSON_FILE=""
 WORKDIR /root
-ENTRYPOINT ["/bin/bash", "-c", "source /etc/profile && exec /usr/share/automation/bin/cirrus-ci_retrospective.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "exec /usr/bin/cirrus-ci_retrospective.sh"]

--- a/cirrus-ci_retrospective/test/testbin-cirrus-ci_retrospective-installer.sh
+++ b/cirrus-ci_retrospective/test/testbin-cirrus-ci_retrospective-installer.sh
@@ -14,6 +14,6 @@ test_cmd "Verify cirrus-ci_retrospective can be installed under $TEMPDIR" \
 
 test_cmd "Verify executing cirrus-ci_retrospective.sh gives 'Expecting' error message" \
     2 '::error::.+Expecting' \
-    env AUTOMATION_LIB_PATH=$TEMPDIR/automation/lib $TEMPDIR/automation/bin/cirrus-ci_retrospective.sh
+    env AUTOMATION_LIB_PATH=$TEMPDIR/share/automation/lib $TEMPDIR/share/automation/bin/cirrus-ci_retrospective.sh
 
 exit_with_status

--- a/common/test/testbin-install_automation.sh
+++ b/common/test/testbin-install_automation.sh
@@ -45,13 +45,13 @@ test_cmd \
 test_cmd \
     "The re-installed version has AUTOMATION_VERSION file matching the current version" \
     0 "$(git describe HEAD)" \
-    cat "$INSTALL_PREFIX/automation/AUTOMATION_VERSION"
+    cat "$INSTALL_PREFIX/share/automation/AUTOMATION_VERSION"
 
 load_example_environment() {
     local _args="$@"
     # Don't disturb testing
     (
-        source "$INSTALL_PREFIX/automation/environment" || return 99
+        source "$INSTALL_PREFIX/share/automation/environment" || return 99
         echo "AUTOMATION_LIB_PATH ==> ${AUTOMATION_LIB_PATH:-UNDEFINED}"
         echo "PATH ==> ${PATH:-EMPTY}"
         [[ -z "$_args" ]] || $_args
@@ -64,12 +64,12 @@ execute_in_example_environment() {
 
 test_cmd \
     "The example environment defines AUTOMATION_LIB_PATH" \
-    0 "AUTOMATION_LIB_PATH ==> $INSTALL_PREFIX/automation/lib" \
+    0 "AUTOMATION_LIB_PATH ==> $INSTALL_PREFIX/share/automation/lib" \
     load_example_environment
 
 test_cmd \
     "The example environment appends to \$PATH" \
-    0 "PATH ==> .+:$INSTALL_PREFIX/automation/bin" \
+    0 "PATH ==> .+:$INSTALL_PREFIX/share/automation/bin" \
     load_example_environment
 
 test_cmd \


### PR DESCRIPTION
When installing as root as recommended, symlink everything in the
installation path's `bin` directory into the `$INSTALL_PREFIX/bin`
directory.  This makes it easier to execute certain standalone binaries
(like the installer).  Otherwise, specifying the full path would be
necessary, even if only to source the environment script.

Also setup `$INSTALL_PREFIX/bin/cirrus-ci_retrospective.sh` during install,
for use in container image.

Signed-off-by: Chris Evich <cevich@redhat.com>