### PR TITLE
Implement key storage in kernel

### DIFF
--- a/ephemeral_gpg/lib/git_unatt_gpg_inline.sh.in
+++ b/ephemeral_gpg/lib/git_unatt_gpg_inline.sh.in
@@ -1,8 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # This is a template for a generated script that feeds a private
 # passphrase from the kernel to gpg, on behalf of an asynchronous
 # call from git.  Not intended to be executed directly.
+
+set -e
+set +x
 
 _obfsctd_b64_kp='@@@@@ SUBSTITUTION TOKEN @@@@@'
 
@@ -13,4 +16,5 @@ _obfsctd_b64_kp='@@@@@ SUBSTITUTION TOKEN @@@@@'
     --passphrase-fd 43 \
     --trust-model tofu+pgp --tofu-default-policy good \
     "$@"
+# Use different fd from other scripts to prevent hard-to-debug accidents
 ) 43<<<$(base64 -d --ignore-garbage <<<"$_obfsctd_b64_kp")

--- a/ephemeral_gpg/lib/git_unatt_gpg_kernel.sh.in
+++ b/ephemeral_gpg/lib/git_unatt_gpg_kernel.sh.in
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This is a template for a generated script that feeds a private
+# passphrase from the kernel to gpg, on behalf of an asynchronous
+# call from git.  Not intended to be executed directly.
+
+set -e
+set +x
+
+_keyring_id='@@@@@ SUBSTITUTION TOKEN @@@@@'
+
+# Interpret variables/substitutions at runtime
+(
+    gpg --quiet --batch --no-tty --pinentry-mode loopback \
+    --passphrase-fd 44 \
+    --trust-model tofu+pgp --tofu-default-policy good \
+    "$@"
+# Use different fd from other scripts to prevent hard-to-debug accidents
+) 44<<<$(keyctl pipe $(base64 -d --ignore-garbage <<<$_keyring_id))

--- a/ephemeral_gpg/lib/git_unattended_gpg.sh
+++ b/ephemeral_gpg/lib/git_unattended_gpg.sh
@@ -1,1 +1,0 @@
-git_unattended_gpg.sh.in


### PR DESCRIPTION
Originally intended to do this, but saving the key directly into a file
was easier for an initial implementation (despite what the comment
said).  This commit actually implements storing the key in the kernel,
when the kernel supports keyring.  Otherwise the old/simple obfuscation
method is used.

Also fixed some spelling mistakes and improved a few comments

Signed-off-by: Chris Evich <cevich@redhat.com>