### PR TITLE
Use dash compatible environment

### DIFF
--- a/bin/install_automation.sh
+++ b/bin/install_automation.sh
@@ -123,7 +123,7 @@ install_automation() {
 # Added on $(date --iso-8601=minutes) by $actual_inst_path/bin/$SCRIPT_FILENAME"
 # Any manual modifications will be lost upon upgrade or reinstall.
 export AUTOMATION_LIB_PATH="$actual_inst_path/lib"
-export PATH="\${PATH:+\$PATH:}$actual_inst_path/bin"
+export PATH="\$PATH:$actual_inst_path/bin"
 EOF
 }
 


### PR DESCRIPTION
Ubuntu defaults to `dash` as the system-wide shell which
means bash-isms in /etc/environment will fail.  Fix this
by reverting to simple-interpretation when referencing `$PATH`
to avoid screwing it up system-wide.

Signed-off-by: Chris Evich <cevich@redhat.com>