### PR TITLE
Fix Ubuntu environment again

### DIFF
--- a/bin/install_automation.sh
+++ b/bin/install_automation.sh
@@ -123,7 +123,7 @@ install_automation() {
 # Added on $(date --iso-8601=minutes) by $actual_inst_path/bin/$SCRIPT_FILENAME"
 # Any manual modifications will be lost upon upgrade or reinstall.
 export AUTOMATION_LIB_PATH="$actual_inst_path/lib"
-export PATH="\$PATH:$actual_inst_path/bin"
+export PATH="$PATH:$actual_inst_path/bin"
 EOF
 }
 

--- a/common/bin/xrtry.sh
+++ b/common/bin/xrtry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefial
+set -eo pipefail
 
 # This scripts is intended to wrap commands which occasionally fail due
 # to external factors like networking hiccups, service failover, load-balancing,


### PR DESCRIPTION
For whatever reason, the embedded PATH variable reference does not get
expanded in /etc/environment.  Fix this by simply dumping whatever
value resolves at install-time.

Also include small typo-fix for xrtry.sh script

Signed-off-by: Chris Evich <cevich@redhat.com>