### PR TITLE
Add shortcut for loading all common libraries

### DIFF
--- a/cirrus-ci_retrospective/lib/ccir_common.sh
+++ b/cirrus-ci_retrospective/lib/ccir_common.sh
@@ -3,6 +3,8 @@
 # Not intended for direct execution
 AUTOMATION_LIB_PATH="${AUTOMATION_LIB_PATH:-$(dirname $(realpath ${BASH_SOURCE[0]}))/../../common/lib}"
 GITHUB_ACTION_LIB="${GITHUB_ACTION_LIB:-$AUTOMATION_LIB_PATH/github_common.sh}"
+# Allow in-place use w/o installing, e.g. for testing
 [[ -r "$GITHUB_ACTION_LIB" ]] || \
     GITHUB_ACTION_LIB="$AUTOMATION_LIB_PATH/../../github/lib/github_common.sh"
+# Also loads common lib
 source "$GITHUB_ACTION_LIB"

--- a/common/lib/common_lib.sh
+++ b/common/lib/common_lib.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This file is intended to be sourced as a short-cut to loading
+# all common libraries one-by-one.
+
+AUTOMATION_LIB_PATH="${AUTOMATION_LIB_PATH:-$(dirname ${BASH_SOURCE[0]})}"
+
+# Filename list must be hard-coded
+# When installed, other files may be present in lib directory
+COMMON_LIBS="anchors.sh defaults.sh utils.sh console_output.sh"
+for filename in $COMMON_LIBS; do
+    source $(dirname "$BASH_SOURCE[0]}")/$filename
+done

--- a/github/lib/github_common.sh
+++ b/github/lib/github_common.sh
@@ -4,21 +4,20 @@
 
 # Important paths defined here
 AUTOMATION_LIB_PATH="${AUTOMATION_LIB_PATH:-$(realpath $(dirname ${BASH_SOURCE[0]})/../../common/lib)}"
-source $AUTOMATION_LIB_PATH/anchors.sh || exit 1
 
 # Override default library message prefixes to those consumed by Github Actions
 # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
 # Doesn't work properly w/o $ACTIONS_STEP_DEBUG=true
 DEBUG_MSG_PREFIX="::debug::"
 # Translation to usage throughout common-library
-if [[ "$ACTIONS_STEP_DEBUG" == 'true' ]]; then
+if [[ "${ACTIONS_STEP_DEBUG:-false}" == 'true' ]]; then
     DEBUG=1
 fi
 # Highlight these messages in the Github Action WebUI
 WARNING_MSG_PREFIX="::warning::"
 ERROR_MSG_PREFIX="::error::"
-source $AUTOMATION_LIB_PATH/defaults.sh || exit 1
-source $AUTOMATION_LIB_PATH/console_output.sh || exit 1
+
+source $AUTOMATION_LIB_PATH/common_lib.sh || exit 1
 
 # usage: set_out_var <name> [value...]
 set_out_var() {


### PR DESCRIPTION
One internal, and several external users of this library don't bother
sourcing individual `common/lib/*.sh` files.  Instead they iterate
over all of them by name, which is messy and inconvenient.  Add a
short-cut script which callers can source to load all common libraries.

Signed-off-by: Chris Evich <cevich@redhat.com>