### PR TITLE
Use dedicated CI container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,11 +7,13 @@ env:
     # Name of the typical destination branch for PRs.
     DEST_BRANCH: "master"
 
+
 # Default task runtime environment
 container:
-    image: quay.io/libpod/cirrus-ci_retrospective:latest
+    dockerfile: ci/Dockerfile
     cpu: 1
     memory: 1
+
 
 # Execute all unit-tests in the repo
 cirrus-ci/test_task:
@@ -24,6 +26,7 @@ cirrus-ci/test_task:
         test_output_artifacts:
             path: '*.log'
 
+
 # Represent primary Cirrus-CI based testing (Required for merge)
 cirrus-ci/success_task:
     depends_on:
@@ -31,6 +34,7 @@ cirrus-ci/success_task:
     clone_script: mkdir -p "$CIRRUS_WORKING_DIR"
     script: >-
         echo "Required for Action Workflow: https://github.com/${CIRRUS_REPO_FULL_NAME}/actions/runs/${GITHUB_CHECK_SUITE_ID}"
+
 
 # Represent secondary Github Action based testing (Required for merge)
 # N/B: NO other task should depend on this task. Doing so will prevent

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.fedoraproject.org/fedora-minimal:latest
+RUN microdnf update -y && \
+    microdnf install -y findutils jq git curl perl-YAML perl-open perl-Data-TreeDumper perl-Test perl-Test-Simple perl-Test-Differences perl-YAML-LibYAML && \
+    microdnf clean all && \
+    rm -rf /var/cache/dnf
+# Required by perl
+ENV LC_ALL="C" \
+    LANG="en_US.UTF-8"

--- a/cirrus-task-map/test/run_all_tests.sh
+++ b/cirrus-task-map/test/run_all_tests.sh
@@ -4,17 +4,6 @@ set -e
 
 testdir=$(dirname $0)
 
-# CI systems are missing important packages needed for this tool; so
-# we'll have to rely on Ed testing manually
-perl_check() {
-    perl -M"$1" -e '1' &> /dev/null && return
-    echo "perl $1 unavailable, skipping $testdir" >&2
-    exit 0
-}
-
-perl_check Test::More
-perl_check YAML::XS
-
 for i in $testdir/*.t;do
     echo -e "\nExecuting $testdir/$i..." >&2
     $i


### PR DESCRIPTION
Specifically, running tests for `cirrus-task-map` requires some perl
modules which are not needed in the `cirrus-ci_retrospective`
container (formerly used for CI).  Having a dedicated container
means the package-set can be specialized for testing needs.

Signed-off-by: Chris Evich <cevich@redhat.com>