### PR TITLE
Update CI Container packages + export env. vars.

### DIFF
--- a/bin/run_all_tests.sh
+++ b/bin/run_all_tests.sh
@@ -4,6 +4,16 @@
 
 set -e
 
+if [[ "$CIRRUS_CI" == "true" ]]; then
+    echo "Running under Cirrus-CI: Exporting all \$CIRRUS_* variables"
+    # Allow tests access to details presented by Cirrus-CI
+    for env_var in $(awk 'BEGIN{for(v in ENVIRON) print v}' | grep -E "^CIRRUS_")
+    do
+        echo "    $env_var=${!env_var}"
+        export $env_var="${!env_var}"
+    done
+fi
+
 this_script_filepath="$(realpath $0)"
 runner_script_filename="$(basename $0)"
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,11 @@
 FROM registry.fedoraproject.org/fedora-minimal:latest
 RUN microdnf update -y && \
-    microdnf install -y findutils jq git curl perl-YAML perl-open perl-Data-TreeDumper perl-Test perl-Test-Simple perl-Test-Differences perl-YAML-LibYAML && \
+    microdnf install -y \
+        findutils jq git curl \
+        perl-YAML perl-interpreter perl-open perl-Data-TreeDumper \
+            perl-Test perl-Test-Simple perl-Test-Differences \
+            perl-YAML-LibYAML perl-FindBin \
+        python3 python3-pip gcc python3-devel && \
     microdnf clean all && \
     rm -rf /var/cache/dnf
 # Required by perl


### PR DESCRIPTION
As of the release of Fedora 33, the FindBin perl module is now provided
by a dedicated package.  Previously it was part of the perl-interpreter
package.

For some unit-tests, it may become necessary in the future to utilize
Cirrus-CI env. vars. if they are set.  Ensure the top-level runner
exports them when they are available.

Signed-off-by: Chris Evich <cevich@redhat.com>