### PR TITLE
Fix code-context references

### DIFF
--- a/common/lib/console_output.sh
+++ b/common/lib/console_output.sh
@@ -25,11 +25,11 @@ _rel_path() {
 # helper, not intended for use outside this file
 _ctx() {
     # Caller's caller details
-    local shortest_source_path=$(_rel_path "${BASH_SOURCE[4]}")
-    local grandparent_func="${FUNCNAME[4]}"
+    local shortest_source_path=$(_rel_path "${BASH_SOURCE[3]}")
+    local grandparent_func="${FUNCNAME[2]}"
     [[ -n "$grandparent_func" ]] || \
         grandparent_func="main"
-    echo "$shortest_source_path:${BASH_LINENO[3]} in ${FUNCNAME[4]}()"
+    echo "$shortest_source_path:${BASH_LINENO[2]} in ${FUNCNAME[3]}()"
 }
 
 # helper, not intended for use outside this file.
@@ -51,7 +51,9 @@ warn() {
 # usage: die <msg> [exit-code]
 die() {
     _fmt_ctx "$ERROR_MSG_PREFIX ${1:-no error message given}" > /dev/stderr
-    exit ${2:-1}
+    local exit_code=${2:-1}
+    ((exit_code==0)) || \
+        exit $exit_code
 }
 
 dbg() {

--- a/common/test/console_output_test_helper.sh
+++ b/common/test/console_output_test_helper.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This helper script is intended for testing several functions
+# which output calling context.  It is intended to only be used
+# by the console-output unit-tests.  They are senitive to
+# the both line-positions and line-content of all the following.
+
+SCRIPT_DIRPATH=$(dirname "${BASH_SOURCE[0]}")
+AUTOMATION_LIB_PATH=$(realpath "$SCRIPT_DIRPATH/../lib")
+source "$AUTOMATION_LIB_PATH/common_lib.sh"
+
+set +e
+
+test_function() {
+    DEBUG=1 dbg "Test dbg message"
+    warn "Test warning message"
+    msg "Test msg message"
+    die "Test die message" 0
+}
+
+DEBUG=1 dbg "Test dbg message"
+warn "Test warning message"
+msg "Test msg message"
+die "Test die message" 0
+
+test_function

--- a/common/test/testlib-console_output.sh
+++ b/common/test/testlib-console_output.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source $(dirname ${BASH_SOURCE[0]})/testlib.sh || exit 1
+SCRIPT_DIRPATH=$(dirname ${BASH_SOURCE[0]})
+source $SCRIPT_DIRPATH/testlib.sh || exit 1
 source "$TEST_DIR"/"$SUBJ_FILENAME" || exit 2
 
 test_message_text="This is the test text for a console_output library unit-test"
@@ -71,6 +72,29 @@ test_cmd \
 DEBUG=1
 basic_tests dbg 0 DEBUG
 DEBUG=0
+
+test_cmd \
+    "All primary output functions include the expected context information" \
+    0 "
+DEBUG: Test dbg message (console_output_test_helper.sh:21 in main())
+\*+
+WARNING: Test warning message  (console_output_test_helper.sh:22 in main())
+\*+
+Test msg message
+\*+
+ERROR: Test die message  (console_output_test_helper.sh:24 in main())
+\*+
+
+DEBUG: Test dbg message (console_output_test_helper.sh:15 in test_function())
+\*+
+WARNING: Test warning message  (console_output_test_helper.sh:16 in test_function())
+\*+
+Test msg message
+\*+
+ERROR: Test die message  (console_output_test_helper.sh:18 in test_function())
+\*+
+" \
+    bash "$SCRIPT_DIRPATH/console_output_test_helper.sh"
 
 export VAR1=foo VAR2=bar VAR3=baz
 test_cmd \

--- a/github/test/testlib-github_common.sh
+++ b/github/test/testlib-github_common.sh
@@ -17,7 +17,7 @@ ACTIONS_STEP_DEBUG=true
 source $TEST_DIR/$SUBJ_FILENAME || exit 1  # can't continue w/o loaded library
 
 test_cmd "The debug message prefix is compatible with github actions commands" \
-    0 '::debug:: This is a test debug message.+common/test/testlib.sh' \
+    0 '::debug:: This is a test debug message' \
     dbg 'This is a test debug message'
 
 unset ACTIONS_STEP_DEBUG
@@ -30,7 +30,7 @@ test_cmd "No debug message shows when ACTIONS_STEP_DEBUG is undefined" \
     dbg 'This debug message should not appear'
 
 test_cmd "The warning message prefix is compatible with github actions commands" \
-    0 '::warning:: This is a test warning message.+testlib-github_common.sh' \
+    0 '::warning:: This is a test warning message' \
     warn 'This is a test warning message'
 
 test_cmd "The github actions command for setting output parameter is formatted as expected" \


### PR DESCRIPTION
Previously due to practical reasons, the unit-tests did a very poor
jobs checking the code-context information shown by functions like
`die()`.  Prior to this commit, the stack-level used was too great,
resulting in unhelpful output such as:

`ERROR: blah blah blah (<stdin>:0 in ())`

Fix the stack-level and context output.  Add a helper-script
and new unit-test to confirm it does not break again in the future.

Signed-off-by: Chris Evich <cevich@redhat.com>