### PR TITLE
Implement cirrus-ci config task env. var. renderer

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,8 @@ RUN microdnf update -y && \
         perl-YAML perl-interpreter perl-open perl-Data-TreeDumper \
             perl-Test perl-Test-Simple perl-Test-Differences \
             perl-YAML-LibYAML perl-FindBin \
-        python3 python3-pip gcc python3-devel && \
+        python3 python3-pip gcc python3-devel \
+        python3-flake8 python3-pep8-naming python3-flake8-docstrings python3-flake8-import-order python3-flake8-polyfill python3-mccabe python3-pep8-naming && \
     microdnf clean all && \
     rm -rf /var/cache/dnf
 # Required by perl

--- a/cirrus-ci_env/cirrus-ci_env.py
+++ b/cirrus-ci_env/cirrus-ci_env.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+
+"""Utility to provide canonical listing of Cirrus-CI tasks and env. vars."""
+
+import argparse
+import re
+import sys
+from typing import Any, Mapping
+
+import yaml
+
+
+def err(msg: str):
+    """Print an error message to stderr and exit non-zero."""
+    print(f"\nError: {msg}", file=sys.stderr, flush=True)
+    sys.exit(1)
+
+
+class DefFmt(dict):
+    """
+    Defaulting-dict helper class for render_env()'s str.format_map().
+
+    See: https://docs.python.org/3.7/library/stdtypes.html#str.format_map
+    """
+
+    dollar_env_var = re.compile(r"\$(\w+)")
+    dollarcurly_env_var = re.compile(r"\$\{(\w+)\}")
+
+    def __missing__(self, key: str) -> str:
+        """Not-found items converted back to shell env var format."""
+        return "${{{0}}}".format(key)
+
+
+class CirrusCfg:
+    """Represent a fully realized list of .cirrus.yml tasks."""
+
+    # Dictionary of global, configuration-wide environment variable values.
+    global_env = None
+
+    # String values representing instance type and image name/path/uri
+    global_type = None
+    global_image = None
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        """Create a new instance, given a parsed .cirrus.yml config object."""
+        if not isinstance(config, dict):
+            whatsit = config.__class__
+            raise TypeError(f"Expected 'config' argument to be a dictionary, not a {whatsit}")
+        # This makes a copy, doesn't touch the original
+        self.global_env = self.render_env(config.get("env", dict()))
+        self.global_type, self.global_image = self.get_type_image(config)
+        self.tasks = self.render_tasks(config)
+        self.names = list(self.tasks.keys())
+        self.names.sort()
+        self.names = tuple(self.names)  # help notice attempts to modify
+
+    def render_env(self, env: Mapping[str, str]) -> Mapping[str, str]:
+        """
+        Repeatedly call format_env() to render out-of-order env key values.
+
+        This is a compromise vs recursion. Since substitution values may be
+        referenced while processing, and dictionary keys have no defined
+        order.  Simply provide multiple chances for the substitution to
+        occur.  On failure, a shell-compatible variable reference is simply
+        left in place.
+        """
+        # There's no simple way to detect when substitutions are
+        # complete, so we mirror Cirrus-CI's behavior which
+        # loops 10 times (according to their support) through
+        # the substitution routine.
+        out = self.format_env(env, self.global_env)
+        for _ in range(9):
+            out = self.format_env(out, self.global_env)
+        return out
+
+    @staticmethod
+    def format_env(env, global_env: Mapping[str, str]) -> Mapping[str, str]:
+        """Replace shell-style references in env values, from global_env then env."""
+        # This method is also used to initialize self.global_env
+        if global_env is None:
+            global_env = dict()
+
+        rep = r"{\1}"  # Shell env var to python format string conversion regex
+        def_fmt = DefFmt(**global_env)  # Assumes global_env already rendered
+
+        for k, v in env.items():
+            if "ENCRYPTED" in str(v):
+                continue
+            _ = def_fmt.dollarcurly_env_var.sub(rep, str(v))
+            def_fmt[k] = def_fmt.dollar_env_var.sub(rep, _)
+        out = dict()
+        for k, v in def_fmt.items():
+            if k in env:  # Don't unnecessarily duplicate globals
+                out[k] = str(v).format_map(def_fmt)
+        return out
+
+    def render_tasks(self, tasks: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Return new tasks dict with envs rendered and matrices unrolled."""
+        result = dict()
+        for k, v in tasks.items():
+            if not k.endswith("_task"):
+                continue
+            # Cirrus-CI uses this defaulting priority order
+            alias = v.get("alias", k.replace("_task", ""))
+            name = v.get("name", alias)
+            if "matrix" in v:
+                # Assume Cirrus-CI accepted this config., don't check name clashes
+                result.update(self.unroll_matrix(name, alias, v))
+            else:
+                task = dict(alias=alias)
+                task["env"] = self.render_env(v.get("env", dict()))
+                task_name = self.render_value(name, task["env"])
+                _ = self.get_type_image(v, self.global_type, self.global_image)
+                self.init_task_type_image(task, *_)
+                result[task_name] = task
+        return result
+
+    def unroll_matrix(self, name_default: str, alias_default: str,
+                      task: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Produce copies of task with attributes replaced from matrix list."""
+        result = dict()
+        for item in task["matrix"]:
+            if "name" not in task and "name" not in item:
+                # Cirrus-CI goes a step further, attempting to generate a
+                # unique name based on alias + matrix attributes.  This is
+                # a very complex process that would be insane to attempt to
+                # duplicate.  Instead, simply require a defined 'name'
+                # attribute in every case, throwing an error if not found.
+                raise ValueError(f"Expecting 'name' attribute in"
+                                 f" '{alias_default}_task'"
+                                 f" or matrix definition: {item}"
+                                 f" for task definition: {task}")
+            # default values for the rendered task - not mutable, needs a copy.
+            matrix_task = dict(alias=alias_default, env=task.get("env").copy())
+            matrix_name = item.get("name", name_default)
+
+            # matrix item env. overwrites task env.
+            matrix_task["env"].update(item.get("env", dict()))
+            matrix_task["env"] = self.render_env(matrix_task["env"])
+            matrix_name = self.render_value(matrix_name, matrix_task["env"])
+
+            # Matrix item overides task dict, overrides global defaults.
+            _ = self.get_type_image(item, self.global_type, self.global_image)
+            matrix_type, matrix_image = self.get_type_image(task, *_)
+            self.init_task_type_image(matrix_task, matrix_type, matrix_image)
+            result[matrix_name] = matrix_task
+        return result
+
+    def render_value(self, value: str, env: Mapping[str, str]) -> str:
+        """Given a string value and task env dict, safely render references."""
+        tmp_env = env.copy()  # don't mess up the original
+        tmp_env["__value__"] = value
+        return self.format_env(tmp_env, self.global_env)["__value__"]
+
+    def get_type_image(self, item: dict,
+                       default_type: str = None,
+                       default_image: str = None) -> tuple:
+        """Given Cirrus-CI config or task dict., return instance type and image."""
+        # Order is significant, VMs always override containers
+        if "gce_instance" in item:
+            return "gcevm", item["gce_instance"].get("image_name", default_image)
+        elif "osx_instance" in item:
+            return "osx", item["osx_instance"].get("image", default_image)
+        elif "image" in item.get("container", ""):
+            return "container", item["container"].get("image", default_image)
+        elif "dockerfile" in item.get("container", ""):
+            return "dockerfile", item["container"].get("dockerfile", default_image)
+        else:
+            inst_type = None
+            if self.global_type is not None:
+                inst_type = default_type
+            inst_image = None
+            if self.global_image is not None:
+                inst_image = default_image
+            return inst_type, inst_image
+
+    def init_task_type_image(self, task: Mapping[str, Any],
+                             task_type: str, task_image: str) -> None:
+        """Render any envs. and assert non-none values for task."""
+        if task_type is None or task_image is None:
+            raise ValueError(f"Invalid instance type "
+                             f"({task_type}) or image ({task_image}) "
+                             f"for task ({task})")
+        task["inst_type"] = task_type
+        task["inst_image"] = self.render_value(task_image, task["env"])
+
+
+class CLI:
+    """Represent command-line-interface runtime state and behaviors."""
+
+    # An argparse parser instance
+    parser = None
+
+    # When valid, namespace instance from parser
+    args = None
+
+    # When loaded successfully, instance of CirrusCFG
+    ccfg = None
+
+    def __init__(self) -> None:
+        """Initialize runtime context based on command-line options and parameters."""
+        self.parser = self.args_parser()
+        self.args = self.parser.parse_args()
+        self.ccfg = CirrusCfg(yaml.safe_load(self.args.filepath))
+        if not len(self.ccfg.names):
+            self.parser.print_help()
+            err(f"No Cirrus-CI tasks found in '{self.args.filepath.name}'")
+
+    def __call__(self) -> None:
+        """Execute request command-line actions."""
+        if self.args.list:
+            for task_name in self.ccfg.names:
+                sys.stdout.write(f"{task_name}\n")
+        elif bool(self.args.inst):
+            task = self.ccfg.tasks[self.valid_name()]
+            inst_type = task['inst_type']
+            inst_image = task['inst_image']
+            sys.stdout.write(f"{inst_type} {inst_image}\n")
+        elif bool(self.args.envs):
+            task = self.ccfg.tasks[self.valid_name()]
+            env = self.ccfg.global_env.copy()
+            env.update(task['env'])
+            keys = list(env.keys())
+            keys.sort()
+            for key in keys:
+                if key.startswith("_"):
+                    continue  # Assume private to Cirrus-CI
+                value = env[key]
+                sys.stdout.write(f'{key}="{value}"\n')
+
+    def args_parser(self) -> argparse.ArgumentParser:
+        """Parse command-line options and arguments."""
+        epilog = "Note: One of --list, --envs, or --inst MUST be specified"
+        parser = argparse.ArgumentParser(description=__doc__,
+                                         epilog=epilog)
+        parser.add_argument('filepath', type=argparse.FileType("rt"),
+                            help="File path to .cirrus.yml",
+                            metavar='<filepath>')
+        mgroup = parser.add_mutually_exclusive_group(required=True)
+        mgroup.add_argument('--list', action='store_true',
+                            help="List canonical task names")
+        mgroup.add_argument('--envs', action='store',
+                            help="List env. vars. for task <name>",
+                            metavar="<name>")
+        mgroup.add_argument('--inst', action='store',
+                            help="List instance type and image for task <name>",
+                            metavar="<name>")
+        return parser
+
+    def valid_name(self) -> str:
+        """Print helpful error message when task name is invalid, or return it."""
+        if self.args.envs is not None:
+            task_name = self.args.envs
+        else:
+            task_name = self.args.inst
+        file_name = self.args.filepath.name
+        if task_name not in self.ccfg.names:
+            self.parser.print_help()
+            err(f"Unknown task name '{task_name}' from '{file_name}'")
+        return task_name
+
+
+if __name__ == "__main__":
+    cli = CLI()
+    cli()

--- a/cirrus-ci_env/test/actual_cirrus.yml
+++ b/cirrus-ci_env/test/actual_cirrus.yml
@@ -1,0 +1,739 @@
+---
+
+# Main collection of env. vars to set for all tasks and scripts.
+env:
+    ####
+    #### Global variables used for all tasks
+    ####
+    # Name of the ultimate destination branch for this CI run, PR or post-merge.
+    DEST_BRANCH: "master"
+    # Overrides default location (/tmp/cirrus) for repo clone
+    GOPATH: &gopath "/var/tmp/go"
+    GOBIN: "${GOPATH}/bin"
+    GOCACHE: "${GOPATH}/cache"
+    GOSRC: &gosrc "/var/tmp/go/src/github.com/containers/podman"
+    CIRRUS_WORKING_DIR: *gosrc
+    # The default is 'sh' if unspecified
+    CIRRUS_SHELL: "/bin/bash"
+    # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
+    SCRIPT_BASE: "./contrib/cirrus"
+    # Runner statistics log file path/name
+    STATS_LOGFILE_SFX: 'runner_stats.log'
+    STATS_LOGFILE: '$GOSRC/${CIRRUS_TASK_NAME}-${STATS_LOGFILE_SFX}'
+
+    ####
+    #### Cache-image names to test with (double-quotes around names are critical)
+    ####
+    FEDORA_NAME: "fedora-33"
+    PRIOR_FEDORA_NAME: "fedora-32"
+    UBUNTU_NAME: "ubuntu-2010"
+    PRIOR_UBUNTU_NAME: "ubuntu-2004"
+
+    # Google-cloud VM Images
+    IMAGE_SUFFIX: "c6524344056676352"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${IMAGE_SUFFIX}"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${IMAGE_SUFFIX}"
+    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "prior-ubuntu-${IMAGE_SUFFIX}"
+
+    # Container FQIN's
+    FEDORA_CONTAINER_FQIN: "quay.io/libpod/fedora_podman:${IMAGE_SUFFIX}"
+    PRIOR_FEDORA_CONTAINER_FQIN: "quay.io/libpod/prior-fedora_podman:${IMAGE_SUFFIX}"
+    UBUNTU_CONTAINER_FQIN: "quay.io/libpod/ubuntu_podman:${IMAGE_SUFFIX}"
+    PRIOR_UBUNTU_CONTAINER_FQIN: "quay.io/libpod/prior-ubuntu_podman:${IMAGE_SUFFIX}"
+
+    ####
+    #### Control variables that determine what to run and how to run it.
+    #### N/B: Required ALL of these are set for every single task.
+    ####
+    TEST_FLAVOR:             # int, sys, ext_svc, validate, automation, etc.
+    TEST_ENVIRON: host       # 'host' or 'container'
+    PODBIN_NAME: podman      # 'podman' or 'remote'
+    PRIV_NAME: root          # 'root' or 'rootless'
+    DISTRO_NV:               # any {PRIOR_,}{FEDORA,UBUNTU}_NAME value
+    VM_IMAGE_NAME:           # One of the "Google-cloud VM Images" (above)
+    CTR_FQIN:                # One of the "Container FQIN's" (above)
+
+
+# Default timeout for each task
+timeout_in: 60m
+
+
+gcp_credentials: ENCRYPTED[a28959877b2c9c36f151781b0a05407218cda646c7d047fc556e42f55e097e897ab63ee78369dae141dcf0b46a9d0cdd]
+
+
+# Default/small container image to execute tasks with
+container: &smallcontainer
+    image: ${CTR_FQIN}
+    # Resources are limited across ALL currently executing tasks
+    # ref: https://cirrus-ci.org/guide/linux/#linux-containers
+    cpu: 2
+    memory: 2
+
+
+# Attempt to prevent flakes by confirming all required external/3rd-party
+# services are available and functional.
+ext_svc_check_task:
+    alias: 'ext_svc_check'  # int. ref. name - required for depends_on reference
+    name: "Ext. services"  # Displayed Title - has no other significance
+    skip: &tags "$CIRRUS_TAG != ''"  # Don't run on tags
+    env:
+        TEST_FLAVOR: ext_svc
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+    # NOTE: The default way Cirrus-CI clones is *NOT* compatible with
+    #       environment expectations in contrib/cirrus/lib.sh.  Specifically
+    #       the 'origin' remote must be defined, and all remote branches/tags
+    #       must be available for reference from CI scripts.
+    clone_script: &full_clone |
+          cd /
+          rm -rf $CIRRUS_WORKING_DIR
+          mkdir -p $CIRRUS_WORKING_DIR
+          git clone --recursive --branch=$DEST_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+          cd $CIRRUS_WORKING_DIR
+          git remote update origin
+          if [[ -n "$CIRRUS_PR" ]]; then # running for a PR
+              git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+              git checkout pull/$CIRRUS_PR
+          else
+              git reset --hard $CIRRUS_CHANGE_IN_REPO
+          fi
+          make install.tools
+
+    setup_script: &setup '$GOSRC/$SCRIPT_BASE/setup_environment.sh'
+    main_script: &main '/usr/bin/time --verbose --output="$STATS_LOGFILE" $GOSRC/$SCRIPT_BASE/runner.sh'
+    always: &runner_stats
+        runner_stats_artifacts:
+            path: ./*-${STATS_LOGFILE_SFX}
+            type: text/plain
+
+
+# Execute some quick checks to confirm this YAML file and all
+# automation-related shell scripts are sane.
+automation_task:
+    alias: 'automation'
+    name: "Check Automation"
+    skip: &branches_and_tags "$CIRRUS_PR == '' || $CIRRUS_TAG != ''" # Don't run on branches/tags
+    container: *smallcontainer
+    env:
+        TEST_FLAVOR: automation
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+        TEST_ENVIRON: container
+    clone_script: *full_clone
+    setup_script: *setup
+    main_script: *main
+    always: *runner_stats
+
+
+# N/B: This task is critical.  It builds all binaries and release archives
+# for the project, using all primary OS platforms and versions.  Assuming
+# the builds are successful, a cache is stored of the entire `$GOPATH`
+# contents.  For all subsequent tasks, the _BUILD_CACHE_HANDLE value
+# is used as a key to reuse this cache, saving both time and money.
+# The only exceptions are tasks which only run inside a container, they
+# will not have access the cache and therefore must rely on cloning the
+# repository.
+build_task:
+    alias: 'build'
+    name: 'Build for $DISTRO_NV'
+    gce_instance: &standardvm
+        image_project: libpod-218412
+        zone: "us-central1-a"
+        cpu: 2
+        memory: "4Gb"
+        # Required to be 200gig, do not modify - has i/o performance impact
+        # according to gcloud CLI tool warning messages.
+        disk: 200
+        image_name: "${VM_IMAGE_NAME}"  # from stdenvars
+    matrix: &platform_axis
+        # Ref: https://cirrus-ci.org/guide/writing-tasks/#matrix-modification
+        - env:  &stdenvars
+              DISTRO_NV: ${FEDORA_NAME}
+              # Not used here, is used in other tasks
+              VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+              CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+              # ID for re-use of build output
+              _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+        # - env:
+        #       DISTRO_NV: ${PRIOR_FEDORA_NAME}
+        #       VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
+        #       CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+        #       _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+        - env:
+              DISTRO_NV: ${UBUNTU_NAME}
+              VM_IMAGE_NAME: ${UBUNTU_CACHE_IMAGE_NAME}
+              CTR_FQIN: ${UBUNTU_CONTAINER_FQIN}
+              _BUILD_CACHE_HANDLE: ${UBUNTU_NAME}-build-${CIRRUS_BUILD_ID}
+        - env:
+              DISTRO_NV: ${PRIOR_UBUNTU_NAME}
+              VM_IMAGE_NAME: ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
+              CTR_FQIN: ${PRIOR_UBUNTU_CONTAINER_FQIN}
+              _BUILD_CACHE_HANDLE: ${PRIOR_UBUNTU_NAME}-build-${CIRRUS_BUILD_ID}
+    env:
+        TEST_FLAVOR: build
+    # Ref: https://cirrus-ci.org/guide/writing-tasks/#cache-instruction
+    gopath_cache:  &gopath_cache
+        folder: *gopath  # Required hard-coded path, no variables.
+        fingerprint_script: echo "$_BUILD_CACHE_HANDLE"
+        # Cheat: Clone here when cache is empty, guaranteeing consistency.
+        populate_script: *full_clone
+    # A normal clone would invalidate useful cache
+    clone_script: &noop mkdir -p $CIRRUS_WORKING_DIR
+    setup_script: *setup
+    main_script: *main
+    always: &binary_artifacts
+        <<: *runner_stats
+        gosrc_artifacts:
+            path: ./*  # Grab everything in top-level $GOSRC
+            type: application/octet-stream
+        binary_artifacts:
+            path: ./bin/*
+            type: application/octet-stream
+
+
+# Confirm the result of building on at least one platform appears sane.
+# This confirms the binaries can be executed, checks --help vs docs, and
+# other essential post-build validation checks.
+validate_task:
+    name: "Validate $DISTRO_NV Build"
+    alias: validate
+    # This task is primarily intended to catch human-errors early on, in a
+    # PR.  Skip it for branch-push, branch-create, and tag-push to improve
+    # automation reliability/speed in those contexts.  Any missed errors due
+    # to nonsequential PR merging practices, will be caught on a future PR,
+    # build or test task failures.
+    skip: *branches_and_tags
+    depends_on:
+        - ext_svc_check
+        - automation
+        - build
+    # golangci-lint is a very, very hungry beast.
+    gce_instance: &bigvm
+        <<: *standardvm
+        cpu: 8
+        memory: "16Gb"
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: validate
+    gopath_cache: &ro_gopath_cache
+        <<: *gopath_cache
+        reupload_on_changes: false
+    clone_script: *noop
+    setup_script: *setup
+    main_script: *main
+    always: *runner_stats
+
+
+# Exercise the "libpod" API with a small set of common
+# operations to ensure they are functional.
+bindings_task:
+    name: "Test Bindings"
+    alias: bindings
+    only_if: &not_docs $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
+    skip: *branches_and_tags
+    depends_on:
+        - build
+    gce_instance: *standardvm
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: bindings
+    gopath_cache: *ro_gopath_cache
+    clone_script: *noop  # Comes from cache
+    setup_script: *setup
+    main_script: *main
+    always: *runner_stats
+
+
+# Build the "libpod" API documentation `swagger.yaml` and
+# publish it to google-cloud-storage (GCS).
+swagger_task:
+    name: "Test Swagger"
+    alias: swagger
+    depends_on:
+        - build
+    gce_instance: *standardvm
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: swagger
+        # TODO: Due to podman 3.0 activity (including new images), avoid
+        # disturbing the status-quo just to incorporate this one new
+        # container image.  Uncomment line below when CI activities normalize.
+        #CTR_FQIN: 'quay.io/libpod/gcsupld:${IMAGE_SUFFIX}'
+        CTR_FQIN: 'quay.io/libpod/gcsupld:c4813063494828032'
+        GCPJSON: ENCRYPTED[asdf1234]
+        GCPNAME: ENCRYPTED[asdf1234]
+        GCPPROJECT: 'libpod-218412'
+    gopath_cache: *ro_gopath_cache
+    clone_script: *noop  # Comes from cache
+    setup_script: *setup
+    main_script: *main
+    always: *binary_artifacts
+
+
+# Check that all included go modules from other sources match
+# what is expected in `vendor/modules.txt` vs `go.mod`.  Also
+# make sure that the generated bindings in pkg/bindings/...
+# are in sync with the code.
+consistency_task:
+    name: "Test Code Consistency"
+    alias: consistency
+    skip: *tags
+    depends_on:
+        - build
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: consistency
+        TEST_ENVIRON: container
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+    clone_script: *full_clone  # build-cache not available to container tasks
+    setup_script: *setup
+    main_script: *main
+    always: *runner_stats
+
+
+# There are several other important variations of podman which
+# must always build successfully.  Most of them are handled in
+# this task, though a few need dedicated tasks which follow.
+alt_build_task:
+    name: "$ALT_NAME"
+    alias: alt_build
+    only_if: *not_docs
+    depends_on:
+        - build
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: "altbuild"
+    gce_instance: *standardvm
+    matrix:
+      - env:
+            ALT_NAME: 'Build Each Commit'
+      - env:
+            ALT_NAME: 'Windows Cross'
+      - env:
+            ALT_NAME: 'Build Without CGO'
+      - env:
+            ALT_NAME: 'Test build RPM'
+      - env:
+            ALT_NAME: 'Alt Arch. Cross'
+    gopath_cache: *ro_gopath_cache
+    clone_script: *noop  # Comes from cache
+    setup_script: *setup
+    main_script: *main
+    always: *binary_artifacts
+
+
+# Confirm building a statically-linked binary is successful
+static_alt_build_task:
+    name: "Static Build"
+    alias: static_alt_build
+    only_if: *not_docs
+    depends_on:
+        - build
+    # Community-maintained task, may fail on occasion.  If so, uncomment
+    # the next line and file an issue with details about the failure.
+    # allow_failures: $CI == $CI
+    gce_instance: *bigvm
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: "altbuild"
+        # gce_instance variation prevents this being included in alt_build_task
+        ALT_NAME: 'Static build'
+        # Do not use 'latest', fixed-version tag for runtime stability.
+        CTR_FQIN: "docker.io/nixos/nix:2.3.6"
+        # Authentication token for pushing the build cache to cachix.
+        # This is critical, it helps to avoid a very lengthy process of
+        # statically building every dependency needed to build podman.
+        # Assuming the pinned nix dependencies in nix/nixpkgs.json have not
+        # changed, this cache will ensure that only the static podman binary is
+        # built.
+        CACHIX_AUTH_TOKEN: ENCRYPTED[asdf1234]
+    setup_script: *setup
+    main_script: *main
+    always: *binary_artifacts
+
+
+# Confirm building the remote client, natively on a Mac OS-X VM.
+osx_alt_build_task:
+    name: "OSX Cross"
+    alias: osx_alt_build
+    depends_on:
+        - build
+    env:
+        <<: *stdenvars
+        # OSX platform variation prevents this being included in alt_build_task
+        TEST_FLAVOR: "altbuild"
+        ALT_NAME: 'OSX Cross'
+    osx_instance:
+        image: 'catalina-base'
+    script:
+        - brew install go
+        - brew install go-md2man
+        - make podman-remote-darwin
+        - make install-podman-remote-darwin-docs
+    always: *binary_artifacts
+
+
+# This task is a stub: In the future it will be used to verify
+# podman is compatible with the docker python-module.
+docker-py_test_task:
+    name: Docker-py Compat.
+    alias: docker-py_test
+    skip: *tags
+    only_if: *not_docs
+    depends_on:
+        - build
+    gce_instance: *standardvm
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: docker-py
+        TEST_ENVIRON: container
+    gopath_cache: *ro_gopath_cache
+    clone_script: *noop  # Comes from cache
+    setup_script: *setup
+    main_script: *main
+    always: *runner_stats
+
+
+# Does exactly what it says, execute the podman unit-tests on all primary
+# platforms and release versions.
+unit_test_task:
+    name: "Unit tests on $DISTRO_NV"
+    alias: unit_test
+    skip: *tags
+    only_if: *not_docs
+    depends_on:
+        - validate
+    matrix: *platform_axis
+    gce_instance: *standardvm
+    env:
+        TEST_FLAVOR: unit
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *runner_stats
+
+
+apiv2_test_task:
+    name: "APIv2 test on $DISTRO_NV"
+    alias: apiv2_test
+    skip: *tags
+    depends_on:
+        - validate
+    gce_instance: *standardvm
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: apiv2
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: &logs_artifacts
+        <<: *runner_stats
+        # Required for `contrib/cirrus/logformatter` to work properly
+        html_artifacts:
+            path: ./*.html
+            type: text/html
+        package_versions_script: '$SCRIPT_BASE/logcollector.sh packages'
+        df_script: '$SCRIPT_BASE/logcollector.sh df'
+        audit_log_script: '$SCRIPT_BASE/logcollector.sh audit'
+        journal_script: '$SCRIPT_BASE/logcollector.sh journal'
+        podman_system_info_script: '$SCRIPT_BASE/logcollector.sh podman'
+        time_script: '$SCRIPT_BASE/logcollector.sh time'
+
+compose_test_task:
+    name: "compose test on $DISTRO_NV"
+    alias: compose_test
+    only_if: *not_docs
+    skip: *tags
+    depends_on:
+        - validate
+    gce_instance: *standardvm
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: compose
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *logs_artifacts
+
+
+# Execute the podman integration tests on all primary platforms and release
+# versions, as root, without involving the podman-remote client.
+local_integration_test_task: &local_integration_test_task
+    # Integration-test task name convention:
+    # <int.|sys.> <podman|remote> <Distro NV> <root|rootless>
+    name: &std_name_fmt "$TEST_FLAVOR $PODBIN_NAME $DISTRO_NV $PRIV_NAME $TEST_ENVIRON"
+    alias: local_integration_test
+    only_if: *not_docs
+    skip: *branches_and_tags
+    depends_on:
+        - unit_test
+    matrix: *platform_axis
+    gce_instance: *standardvm
+    timeout_in: 90m
+    env:
+        TEST_FLAVOR: int
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: &int_logs_artifacts
+        <<: *logs_artifacts
+        ginkgo_node_logs_artifacts:
+            path: ./test/e2e/ginkgo-node-*.log
+            type: text/plain
+
+
+# Nearly identical to `local_integration_test` except all operations
+# are performed through the podman-remote client vs a podman "server"
+# running on the same host.
+remote_integration_test_task:
+    <<: *local_integration_test_task
+    alias: remote_integration_test
+    env:
+        TEST_FLAVOR: int
+        PODBIN_NAME: remote
+
+
+# Run the complete set of integration tests from inside a container.
+# This verifies all/most operations function with "podman-in-podman".
+container_integration_test_task:
+    name: *std_name_fmt
+    alias: container_integration_test
+    only_if: *not_docs
+    skip: *branches_and_tags
+    depends_on:
+        - unit_test
+    matrix: &fedora_vm_axis
+        - env:
+              DISTRO_NV: ${FEDORA_NAME}
+              _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+              VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+              CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+        # - env:
+        #       DISTRO_NV: ${PRIOR_FEDORA_NAME}
+        #       _BUILD_CACHE_HANDLE: ${PRIOR_FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+        #       VM_IMAGE_NAME: ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
+        #       CTR_FQIN: ${PRIOR_FEDORA_CONTAINER_FQIN}
+    gce_instance: *standardvm
+    timeout_in: 90m
+    env:
+        TEST_FLAVOR: int
+        TEST_ENVIRON: container
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *int_logs_artifacts
+
+
+# Execute most integration tests as a regular (non-root) user.
+rootless_integration_test_task:
+    name: *std_name_fmt
+    alias: rootless_integration_test
+    only_if: *not_docs
+    skip: *branches_and_tags
+    depends_on:
+        - unit_test
+    matrix: *fedora_vm_axis
+    gce_instance: *standardvm
+    timeout_in: 90m
+    env:
+        TEST_FLAVOR: int
+        PRIV_NAME: rootless
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *int_logs_artifacts
+
+
+# Always run subsequent to integration tests.  While parallelism is lost
+# with runtime, debugging system-test failures can be more challenging
+# for some golang developers.  Otherwise the following tasks run across
+# the same matrix as the integration-tests (above).
+local_system_test_task: &local_system_test_task
+    name: *std_name_fmt
+    alias: local_system_test
+    skip: *tags
+    only_if: *not_docs
+    depends_on:
+      - local_integration_test
+    matrix: *platform_axis
+    gce_instance: *standardvm
+    env:
+        TEST_FLAVOR: sys
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *logs_artifacts
+
+
+remote_system_test_task:
+    <<: *local_system_test_task
+    alias: remote_system_test
+    depends_on:
+      - remote_integration_test
+    env:
+        TEST_FLAVOR: sys
+        PODBIN_NAME: remote
+
+
+rootless_system_test_task:
+    name: *std_name_fmt
+    alias: rootless_system_test
+    skip: *tags
+    only_if: *not_docs
+    depends_on:
+      - rootless_integration_test
+    matrix: *fedora_vm_axis
+    gce_instance: *standardvm
+    env:
+        TEST_FLAVOR: sys
+        PRIV_NAME: rootless
+    clone_script: *noop  # Comes from cache
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *logs_artifacts
+
+# FIXME: we may want to consider running this from nightly cron instead of CI.
+# The tests are actually pretty quick (less than a minute) but they do rely
+# on pulling images from quay.io, which means we're subject to network flakes.
+#
+# FIXME: how does this env matrix work, anyway? Does it spin up multiple VMs?
+# We might just want to encode the version matrix in runner.sh instead
+upgrade_test_task:
+    name: "Upgrade test: from $PODMAN_UPGRADE_FROM"
+    alias: upgrade_test
+    skip: *tags
+    only_if: *not_docs
+    depends_on:
+      - local_system_test
+    matrix:
+        - env:
+              PODMAN_UPGRADE_FROM: v1.9.0
+        - env:
+              PODMAN_UPGRADE_FROM: v2.0.6
+        - env:
+              PODMAN_UPGRADE_FROM: v2.1.1
+    gce_instance: *standardvm
+    env:
+        TEST_FLAVOR: upgrade_test
+        DISTRO_NV: ${FEDORA_NAME}
+        VM_IMAGE_NAME: ${FEDORA_CACHE_IMAGE_NAME}
+        # ID for re-use of build output
+        _BUILD_CACHE_HANDLE: ${FEDORA_NAME}-build-${CIRRUS_BUILD_ID}
+    clone_script: *noop
+    gopath_cache: *ro_gopath_cache
+    setup_script: *setup
+    main_script: *main
+    always: *logs_artifacts
+
+# This task is critical.  It updates the "last-used by" timestamp stored
+# in metadata for all VM images.  This mechanism functions in tandem with
+# an out-of-band pruning operation to remove disused VM images.
+meta_task:
+    name: "VM img. keepalive"
+    alias: meta
+    container:
+        cpu: 2
+        memory: 2
+        image: quay.io/libpod/imgts:$IMAGE_SUFFIX
+    env:
+        # Space-separated list of images used by this repository state
+        IMGNAMES: >-
+            ${FEDORA_CACHE_IMAGE_NAME}
+            ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
+            ${UBUNTU_CACHE_IMAGE_NAME}
+            ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
+        BUILDID: "${CIRRUS_BUILD_ID}"
+        REPOREF: "${CIRRUS_REPO_NAME}"
+        GCPJSON: ENCRYPTED[asdf1234]
+        GCPNAME: ENCRYPTED[asdf1234]
+        GCPPROJECT: libpod-218412
+    clone_script: *noop
+    script: /usr/local/bin/entrypoint.sh
+
+
+# Status aggregator for all tests.  This task simply ensures a defined
+# set of tasks all passed, and allows confirming that based on the status
+# of this task.
+success_task:
+    name: "Total Success"
+    alias: success
+    # N/B: ALL tasks must be listed here, minus their '_task' suffix.
+    depends_on:
+        - ext_svc_check
+        - automation
+        - build
+        - validate
+        - bindings
+        - swagger
+        - consistency
+        - alt_build
+        - static_alt_build
+        - osx_alt_build
+        - docker-py_test
+        - unit_test
+        - apiv2_test
+        - compose_test
+        - local_integration_test
+        - remote_integration_test
+        - rootless_integration_test
+        - container_integration_test
+        - local_system_test
+        - remote_system_test
+        - rootless_system_test
+        - upgrade_test
+        - meta
+    env:
+        CTR_FQIN: ${FEDORA_CONTAINER_FQIN}
+        TEST_ENVIRON: container
+    clone_script: *noop
+    script: /bin/true
+
+
+# When a new tag is pushed, confirm that the code and commits
+# meet criteria for an official release.
+release_task:
+    name: "Verify Release"
+    alias: release
+    only_if: *tags
+    depends_on:
+        - success
+    gce_instance: *standardvm
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: release
+    gopath_cache: *ro_gopath_cache
+    clone_script: *noop  # Comes from cache
+    setup_script: *setup
+    main_script: *main
+    always: *binary_artifacts
+
+
+# When preparing to release a new version, this task may be manually
+# activated at the PR stage to verify the build is proper for a potential
+# podman release.
+#
+# Note: This cannot use a YAML alias on 'release_task' as of this
+# comment, it is incompatible with 'trigger_type: manual'
+release_test_task:
+    name: "Optional Release Test"
+    alias: release_test
+    only_if: $CIRRUS_PR != ''
+    trigger_type: manual
+    depends_on:
+        - success
+    gce_instance: *standardvm
+    env:
+        <<: *stdenvars
+        TEST_FLAVOR: release
+    gopath_cache: *ro_gopath_cache
+    clone_script: *noop  # Comes from cache
+    setup_script: *setup
+    main_script: *main
+    always: *binary_artifacts

--- a/cirrus-ci_env/test/actual_task_names.txt
+++ b/cirrus-ci_env/test/actual_task_names.txt
@@ -1,0 +1,44 @@
+APIv2 test on fedora-33
+Alt Arch. Cross
+Build Each Commit
+Build Without CGO
+Build for fedora-33
+Build for ubuntu-2004
+Build for ubuntu-2010
+Check Automation
+Docker-py Compat.
+Ext. services
+OSX Cross
+Optional Release Test
+Static Build
+Test Bindings
+Test Code Consistency
+Test Swagger
+Test build RPM
+Total Success
+Unit tests on fedora-33
+Unit tests on ubuntu-2004
+Unit tests on ubuntu-2010
+Upgrade test: from v1.9.0
+Upgrade test: from v2.0.6
+Upgrade test: from v2.1.1
+VM img. keepalive
+Validate fedora-33 Build
+Verify Release
+Windows Cross
+compose test on fedora-33
+int podman fedora-33 root container
+int podman fedora-33 root host
+int podman fedora-33 rootless host
+int podman ubuntu-2004 root host
+int podman ubuntu-2010 root host
+int remote fedora-33 root host
+int remote ubuntu-2004 root host
+int remote ubuntu-2010 root host
+sys podman fedora-33 root host
+sys podman fedora-33 rootless host
+sys podman ubuntu-2004 root host
+sys podman ubuntu-2010 root host
+sys remote fedora-33 root host
+sys remote ubuntu-2004 root host
+sys remote ubuntu-2010 root host

--- a/cirrus-ci_env/test/expected_cirrus.yml
+++ b/cirrus-ci_env/test/expected_cirrus.yml
@@ -1,0 +1,398 @@
+---
+
+global_env:
+  CIRRUS_SHELL: /bin/bash
+  CIRRUS_WORKING_DIR: /var/tmp/go/src/github.com/containers/podman
+  CTR_FQIN: None
+  DEST_BRANCH: master
+  DISTRO_NV: None
+  FEDORA_CACHE_IMAGE_NAME: fedora-c6524344056676352
+  FEDORA_CONTAINER_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+  FEDORA_NAME: fedora-33
+  GOBIN: /var/tmp/go/bin
+  GOCACHE: /var/tmp/go/cache
+  GOPATH: /var/tmp/go
+  GOSRC: /var/tmp/go/src/github.com/containers/podman
+  IMAGE_SUFFIX: c6524344056676352
+  PODBIN_NAME: podman
+  PRIOR_FEDORA_CACHE_IMAGE_NAME: prior-fedora-c6524344056676352
+  PRIOR_FEDORA_CONTAINER_FQIN: quay.io/libpod/prior-fedora_podman:c6524344056676352
+  PRIOR_FEDORA_NAME: fedora-32
+  PRIOR_UBUNTU_CACHE_IMAGE_NAME: prior-ubuntu-c6524344056676352
+  PRIOR_UBUNTU_CONTAINER_FQIN: quay.io/libpod/prior-ubuntu_podman:c6524344056676352
+  PRIOR_UBUNTU_NAME: ubuntu-2004
+  PRIV_NAME: root
+  SCRIPT_BASE: ./contrib/cirrus
+  STATS_LOGFILE: /var/tmp/go/src/github.com/containers/podman/${CIRRUS_TASK_NAME}-runner_stats.log
+  STATS_LOGFILE_SFX: runner_stats.log
+  TEST_ENVIRON: host
+  TEST_FLAVOR: None
+  UBUNTU_CACHE_IMAGE_NAME: ubuntu-c6524344056676352
+  UBUNTU_CONTAINER_FQIN: quay.io/libpod/ubuntu_podman:c6524344056676352
+  UBUNTU_NAME: ubuntu-2010
+  VM_IMAGE_NAME: None
+
+tasks:
+  APIv2 test on fedora-33:
+    alias: apiv2_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: apiv2
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Alt Arch. Cross:
+    alias: alt_build
+    env:
+      ALT_NAME: Alt Arch. Cross
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: altbuild
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Build Each Commit:
+    alias: alt_build
+    env:
+      ALT_NAME: Build Each Commit
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: altbuild
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Build Without CGO:
+    alias: alt_build
+    env:
+      ALT_NAME: Build Without CGO
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: altbuild
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Build for fedora-33:
+    alias: build
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: build
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Build for ubuntu-2004:
+    alias: build
+    env:
+      CTR_FQIN: quay.io/libpod/prior-ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2004
+      TEST_FLAVOR: build
+      VM_IMAGE_NAME: prior-ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2004-build-${CIRRUS_BUILD_ID}
+  Build for ubuntu-2010:
+    alias: build
+    env:
+      CTR_FQIN: quay.io/libpod/ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2010
+      TEST_FLAVOR: build
+      VM_IMAGE_NAME: ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2010-build-${CIRRUS_BUILD_ID}
+  Check Automation:
+    alias: automation
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      TEST_ENVIRON: container
+      TEST_FLAVOR: automation
+  Docker-py Compat.:
+    alias: docker-py_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_ENVIRON: container
+      TEST_FLAVOR: docker-py
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Ext. services:
+    alias: ext_svc_check
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      TEST_FLAVOR: ext_svc
+  OSX Cross:
+    alias: osx_alt_build
+    env:
+      ALT_NAME: OSX Cross
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: altbuild
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Optional Release Test:
+    alias: release_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: release
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Static Build:
+    alias: static_alt_build
+    env:
+      ALT_NAME: Static build
+      CTR_FQIN: docker.io/nixos/nix:2.3.6
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: altbuild
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Test Bindings:
+    alias: bindings
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: bindings
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Test Code Consistency:
+    alias: consistency
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_ENVIRON: container
+      TEST_FLAVOR: consistency
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Test Swagger:
+    alias: swagger
+    env:
+      CTR_FQIN: quay.io/libpod/gcsupld:c4813063494828032
+      DISTRO_NV: fedora-33
+      GCPPROJECT: libpod-218412
+      TEST_FLAVOR: swagger
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Test build RPM:
+    alias: alt_build
+    env:
+      ALT_NAME: Test build RPM
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: altbuild
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Total Success:
+    alias: success
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      TEST_ENVIRON: container
+  Unit tests on fedora-33:
+    alias: unit_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: unit
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Unit tests on ubuntu-2004:
+    alias: unit_test
+    env:
+      CTR_FQIN: quay.io/libpod/prior-ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2004
+      TEST_FLAVOR: unit
+      VM_IMAGE_NAME: prior-ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2004-build-${CIRRUS_BUILD_ID}
+  Unit tests on ubuntu-2010:
+    alias: unit_test
+    env:
+      CTR_FQIN: quay.io/libpod/ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2010
+      TEST_FLAVOR: unit
+      VM_IMAGE_NAME: ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2010-build-${CIRRUS_BUILD_ID}
+  'Upgrade test: from v1.9.0':
+    alias: upgrade_test
+    env:
+      DISTRO_NV: fedora-33
+      PODMAN_UPGRADE_FROM: v1.9.0
+      TEST_FLAVOR: upgrade_test
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  'Upgrade test: from v2.0.6':
+    alias: upgrade_test
+    env:
+      DISTRO_NV: fedora-33
+      PODMAN_UPGRADE_FROM: v2.0.6
+      TEST_FLAVOR: upgrade_test
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  'Upgrade test: from v2.1.1':
+    alias: upgrade_test
+    env:
+      DISTRO_NV: fedora-33
+      PODMAN_UPGRADE_FROM: v2.1.1
+      TEST_FLAVOR: upgrade_test
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  VM img. keepalive:
+    alias: meta
+    env:
+      BUILDID: ${CIRRUS_BUILD_ID}
+      GCPPROJECT: libpod-218412
+      IMGNAMES: fedora-c6524344056676352 prior-fedora-c6524344056676352 ubuntu-c6524344056676352
+        prior-ubuntu-c6524344056676352
+      REPOREF: ${CIRRUS_REPO_NAME}
+  Validate fedora-33 Build:
+    alias: validate
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: validate
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Verify Release:
+    alias: release
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: release
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Windows Cross:
+    alias: alt_build
+    env:
+      ALT_NAME: Windows Cross
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: altbuild
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  compose test on fedora-33:
+    alias: compose_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: compose
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  int podman fedora-33 root container:
+    alias: container_integration_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_ENVIRON: container
+      TEST_FLAVOR: int
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  int podman fedora-33 root host:
+    alias: local_integration_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: int
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  int podman fedora-33 rootless host:
+    alias: rootless_integration_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      PRIV_NAME: rootless
+      TEST_FLAVOR: int
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  int podman ubuntu-2004 root host:
+    alias: local_integration_test
+    env:
+      CTR_FQIN: quay.io/libpod/prior-ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2004
+      TEST_FLAVOR: int
+      VM_IMAGE_NAME: prior-ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2004-build-${CIRRUS_BUILD_ID}
+  int podman ubuntu-2010 root host:
+    alias: local_integration_test
+    env:
+      CTR_FQIN: quay.io/libpod/ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2010
+      TEST_FLAVOR: int
+      VM_IMAGE_NAME: ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2010-build-${CIRRUS_BUILD_ID}
+  int remote fedora-33 root host:
+    alias: remote_integration_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      PODBIN_NAME: remote
+      TEST_FLAVOR: int
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  int remote ubuntu-2004 root host:
+    alias: remote_integration_test
+    env:
+      CTR_FQIN: quay.io/libpod/prior-ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2004
+      PODBIN_NAME: remote
+      TEST_FLAVOR: int
+      VM_IMAGE_NAME: prior-ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2004-build-${CIRRUS_BUILD_ID}
+  int remote ubuntu-2010 root host:
+    alias: remote_integration_test
+    env:
+      CTR_FQIN: quay.io/libpod/ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2010
+      PODBIN_NAME: remote
+      TEST_FLAVOR: int
+      VM_IMAGE_NAME: ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2010-build-${CIRRUS_BUILD_ID}
+  sys podman fedora-33 root host:
+    alias: local_system_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      TEST_FLAVOR: sys
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  sys podman fedora-33 rootless host:
+    alias: rootless_system_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      PRIV_NAME: rootless
+      TEST_FLAVOR: sys
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  sys podman ubuntu-2004 root host:
+    alias: local_system_test
+    env:
+      CTR_FQIN: quay.io/libpod/prior-ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2004
+      TEST_FLAVOR: sys
+      VM_IMAGE_NAME: prior-ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2004-build-${CIRRUS_BUILD_ID}
+  sys podman ubuntu-2010 root host:
+    alias: local_system_test
+    env:
+      CTR_FQIN: quay.io/libpod/ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2010
+      TEST_FLAVOR: sys
+      VM_IMAGE_NAME: ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2010-build-${CIRRUS_BUILD_ID}
+  sys remote fedora-33 root host:
+    alias: remote_system_test
+    env:
+      CTR_FQIN: quay.io/libpod/fedora_podman:c6524344056676352
+      DISTRO_NV: fedora-33
+      PODBIN_NAME: remote
+      TEST_FLAVOR: sys
+      VM_IMAGE_NAME: fedora-c6524344056676352
+      _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  sys remote ubuntu-2004 root host:
+    alias: remote_system_test
+    env:
+      CTR_FQIN: quay.io/libpod/prior-ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2004
+      PODBIN_NAME: remote
+      TEST_FLAVOR: sys
+      VM_IMAGE_NAME: prior-ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2004-build-${CIRRUS_BUILD_ID}
+  sys remote ubuntu-2010 root host:
+    alias: remote_system_test
+    env:
+      CTR_FQIN: quay.io/libpod/ubuntu_podman:c6524344056676352
+      DISTRO_NV: ubuntu-2010
+      PODBIN_NAME: remote
+      TEST_FLAVOR: sys
+      VM_IMAGE_NAME: ubuntu-c6524344056676352
+      _BUILD_CACHE_HANDLE: ubuntu-2010-build-${CIRRUS_BUILD_ID}

--- a/cirrus-ci_env/test/expected_ti.yml
+++ b/cirrus-ci_env/test/expected_ti.yml
@@ -1,0 +1,132 @@
+APIv2 test on fedora-33:
+- gcevm
+- fedora-c6524344056676352
+Alt Arch. Cross:
+- gcevm
+- fedora-c6524344056676352
+Build Each Commit:
+- gcevm
+- fedora-c6524344056676352
+Build Without CGO:
+- gcevm
+- fedora-c6524344056676352
+Build for fedora-33:
+- gcevm
+- fedora-c6524344056676352
+Build for ubuntu-2004:
+- gcevm
+- prior-ubuntu-c6524344056676352
+Build for ubuntu-2010:
+- gcevm
+- ubuntu-c6524344056676352
+Check Automation:
+- container
+- quay.io/libpod/fedora_podman:c6524344056676352
+Docker-py Compat.:
+- gcevm
+- fedora-c6524344056676352
+Ext. services:
+- container
+- quay.io/libpod/fedora_podman:c6524344056676352
+OSX Cross:
+- osx
+- catalina-base
+Optional Release Test:
+- gcevm
+- fedora-c6524344056676352
+Static Build:
+- gcevm
+- fedora-c6524344056676352
+Test Bindings:
+- gcevm
+- fedora-c6524344056676352
+Test Code Consistency:
+- container
+- quay.io/libpod/fedora_podman:c6524344056676352
+Test Swagger:
+- gcevm
+- fedora-c6524344056676352
+Test build RPM:
+- gcevm
+- fedora-c6524344056676352
+Total Success:
+- container
+- quay.io/libpod/fedora_podman:c6524344056676352
+Unit tests on fedora-33:
+- gcevm
+- fedora-c6524344056676352
+Unit tests on ubuntu-2004:
+- gcevm
+- prior-ubuntu-c6524344056676352
+Unit tests on ubuntu-2010:
+- gcevm
+- ubuntu-c6524344056676352
+'Upgrade test: from v1.9.0':
+- gcevm
+- fedora-c6524344056676352
+'Upgrade test: from v2.0.6':
+- gcevm
+- fedora-c6524344056676352
+'Upgrade test: from v2.1.1':
+- gcevm
+- fedora-c6524344056676352
+VM img. keepalive:
+- container
+- quay.io/libpod/imgts:c6524344056676352
+Validate fedora-33 Build:
+- gcevm
+- fedora-c6524344056676352
+Verify Release:
+- gcevm
+- fedora-c6524344056676352
+Windows Cross:
+- gcevm
+- fedora-c6524344056676352
+compose test on fedora-33:
+- gcevm
+- fedora-c6524344056676352
+int podman fedora-33 root container:
+- gcevm
+- fedora-c6524344056676352
+int podman fedora-33 root host:
+- gcevm
+- fedora-c6524344056676352
+int podman fedora-33 rootless host:
+- gcevm
+- fedora-c6524344056676352
+int podman ubuntu-2004 root host:
+- gcevm
+- prior-ubuntu-c6524344056676352
+int podman ubuntu-2010 root host:
+- gcevm
+- ubuntu-c6524344056676352
+int remote fedora-33 root host:
+- gcevm
+- fedora-c6524344056676352
+int remote ubuntu-2004 root host:
+- gcevm
+- prior-ubuntu-c6524344056676352
+int remote ubuntu-2010 root host:
+- gcevm
+- ubuntu-c6524344056676352
+sys podman fedora-33 root host:
+- gcevm
+- fedora-c6524344056676352
+sys podman fedora-33 rootless host:
+- gcevm
+- fedora-c6524344056676352
+sys podman ubuntu-2004 root host:
+- gcevm
+- prior-ubuntu-c6524344056676352
+sys podman ubuntu-2010 root host:
+- gcevm
+- ubuntu-c6524344056676352
+sys remote fedora-33 root host:
+- gcevm
+- fedora-c6524344056676352
+sys remote ubuntu-2004 root host:
+- gcevm
+- prior-ubuntu-c6524344056676352
+sys remote ubuntu-2010 root host:
+- gcevm
+- ubuntu-c6524344056676352

--- a/cirrus-ci_env/test/run_all_tests.sh
+++ b/cirrus-ci_env/test/run_all_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname ${BASH_SOURCE[0]})
+./test_cirrus-ci_env.py
+./testbin-cirrus-ci_env.sh
+
+if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+    echo "Lint/Style checking not supported under github actions: Skipping"
+    exit 0
+elif [[ -x $(type -P flake8-3) ]]; then
+    cd ..
+    flake8-3 --max-line-length=100 . test
+    flake8-3 --max-line-length=100 --extend-ignore=D101,D102 test
+else
+    echo "Can't find flake-8-3 binary, is script executing inside CI container?"
+    exit 1
+fi

--- a/cirrus-ci_env/test/test_cirrus-ci_env.py
+++ b/cirrus-ci_env/test/test_cirrus-ci_env.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+
+"""Verify cirrus-ci_env.py functions as expected."""
+
+import importlib.util
+import os
+import sys
+import unittest
+import unittest.mock as mock
+
+import yaml
+
+# Assumes directory structure of this file relative to repo.
+TEST_DIRPATH = os.path.dirname(os.path.realpath(__file__))
+SCRIPT_FILENAME = os.path.basename(__file__).replace('test_', '')
+SCRIPT_DIRPATH = os.path.realpath(os.path.join(TEST_DIRPATH, '..', SCRIPT_FILENAME))
+
+
+class TestBase(unittest.TestCase):
+    """Base test class fixture."""
+
+    def setUp(self):
+        """Initialize before every test."""
+        super().setUp()
+        spec = importlib.util.spec_from_file_location("cci_env", SCRIPT_DIRPATH)
+        self.cci_env = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.cci_env)
+
+    def tearDown(self):
+        """Finalize after every test."""
+        del self.cci_env
+        try:
+            del sys.modules["cci_env"]
+        except KeyError:
+            pass
+
+
+class TestEnvRender(TestBase):
+    """Confirming Cirrus-CI in-line env. var. rendering behaviors."""
+
+    def setUp(self):
+        """Initialize before every test."""
+        super().setUp()
+        self.fake_cirrus = mock.Mock(spec=self.cci_env.CirrusCfg)
+        attrs = {"format_env.side_effect": self.cci_env.CirrusCfg.format_env,
+                 "render_env.side_effect": self.cci_env.CirrusCfg.render_env,
+                 "render_value.side_effect": self.cci_env.CirrusCfg.render_value,
+                 "get_type_image.return_value": (None, None),
+                 "init_task_type_image.return_value": None}
+        self.fake_cirrus.configure_mock(**attrs)
+        self.render_env = self.fake_cirrus.render_env
+        self.render_value = self.fake_cirrus.render_value
+
+    def test_empty(self):
+        """Verify an empty env dict is unmodified."""
+        self.fake_cirrus.global_env = None
+        result = self.render_env(self.fake_cirrus, {})
+        self.assertDictEqual(result, {})
+
+    def test_simple_string(self):
+        """Verify an simple string value is unmodified."""
+        self.fake_cirrus.global_env = None
+        result = self.render_env(self.fake_cirrus, dict(foo="bar"))
+        self.assertDictEqual(result, dict(foo="bar"))
+
+    def test_simple_sub(self):
+        """Verify that a simple string substitution is performed."""
+        self.fake_cirrus.global_env = None
+        result = self.render_env(self.fake_cirrus, dict(foo="$bar", bar="foo"))
+        self.assertDictEqual(result, dict(foo="foo", bar="foo"))
+
+    def test_simple_multi(self):
+        """Verify that multiple string substitution are performed."""
+        self.fake_cirrus.global_env = None
+        result = self.render_env(self.fake_cirrus,
+                                 dict(foo="$bar", bar="$baz", baz="foobarbaz"))
+        self.assertDictEqual(result,
+                             dict(foo="foobarbaz", bar="foobarbaz", baz="foobarbaz"))
+
+    def test_simple_undefined(self):
+        """Verify an undefined substitution falls back to dollar-curly env var."""
+        self.fake_cirrus.global_env = None
+        result = self.render_env(self.fake_cirrus, dict(foo="$baz", bar="${jar}"))
+        self.assertDictEqual(result, dict(foo="${baz}", bar="${jar}"))
+
+    def test_simple_global(self):
+        """Verify global keys not duplicated into env."""
+        self.fake_cirrus.global_env = dict(bar="baz")
+        result = self.render_env(self.fake_cirrus, dict(foo="bar"))
+        self.assertDictEqual(result, dict(foo="bar"))
+
+    def test_simple_globalsub(self):
+        """Verify global keys render substitutions."""
+        self.fake_cirrus.global_env = dict(bar="baz")
+        result = self.render_env(self.fake_cirrus, dict(foo="${bar}"))
+        self.assertDictEqual(result, dict(foo="baz"))
+
+    def test_readonly_params(self):
+        """Verify global keys not modified while rendering substitutions."""
+        original_global_env = dict(
+            foo="foo", bar="bar", baz="baz", test="$item")
+        self.fake_cirrus.global_env = dict(**original_global_env)  # A copy
+        original_env = dict(item="${foo}$bar${baz}")
+        env = dict(**original_env)  # A copy
+        result = self.render_env(self.fake_cirrus, env)
+        self.assertDictEqual(self.fake_cirrus.global_env, original_global_env)
+        self.assertDictEqual(env, original_env)
+        self.assertDictEqual(result, dict(item="foobarbaz"))
+
+    def test_render_value(self):
+        """Verify render_value() works by not modifying env parameter."""
+        self.fake_cirrus.global_env = dict(foo="foo", bar="bar", baz="baz")
+        original_env = dict(item="snafu")
+        env = dict(**original_env)  # A copy
+        test_value = "$foo${bar}$baz $item"
+        expected_value = "foobarbaz snafu"
+        actual_value = self.render_value(self.fake_cirrus, test_value, env)
+        self.assertDictEqual(env, original_env)
+        self.assertEqual(actual_value, expected_value)
+
+
+class TestRenderTasks(TestBase):
+    """Fixture for exercising Cirrus-CI task-level env. and matrix rendering behaviors."""
+
+    def setUp(self):
+        """Initialize before every test."""
+        super().setUp()
+        self.CCfg = self.cci_env.CirrusCfg
+        self.global_env = dict(foo="foo", bar="bar", baz="baz")
+        self.patchers = (
+            mock.patch.object(self.CCfg, 'get_type_image',
+                              mock.Mock(return_value=(None, None))),
+            mock.patch.object(self.CCfg, 'init_task_type_image',
+                              mock.Mock(return_value=None)))
+        for patcher in self.patchers:
+            patcher.start()
+
+    def tearDown(self):
+        """Finalize after every test."""
+        for patcher in self.patchers:
+            patcher.stop()
+        super().tearDown()
+
+    def test_empty_in_empty_out(self):
+        """Verify initializing with empty tasks and globals results in empty output."""
+        result = self.CCfg(dict(env=dict())).tasks
+        self.assertDictEqual(result, dict())
+
+    def test_simple_render(self):
+        """Verify rendering of task local and global env. vars."""
+        env = dict(item="${foo}$bar${baz}", test="$undefined")
+        task = dict(something="ignored", env=env)
+        config = dict(env=self.global_env, test_task=task)
+        expected = {
+            "test": {
+                "alias": "test",
+                "env": {
+                    "item": "foobarbaz",
+                    "test": "${undefined}"
+                }
+            }
+        }
+        result = self.CCfg(config).tasks
+        self.assertDictEqual(result, expected)
+
+    def test_simple_matrix(self):
+        """Verify unrolling of a simple matrix containing two tasks."""
+        matrix1 = dict(name="test_matrix1", env=dict(item="${foo}bar"))
+        matrix2 = dict(name="test_matrix2", env=dict(item="foo$baz"))
+        task = dict(env=dict(something="untouched"), matrix=[matrix1, matrix2])
+        config = dict(env=self.global_env, test_task=task)
+        expected = {
+            "test_matrix1": {
+                "alias": "test",
+                "env": {
+                    "item": "foobar",
+                    "something": "untouched"
+                }
+            },
+            "test_matrix2": {
+                "alias": "test",
+                "env": {
+                    "item": "foobaz",
+                    "something": "untouched"
+                }
+            }
+        }
+        result = self.CCfg(config).tasks
+        self.assertNotIn('test_task', result)
+        for task_name in ('test_matrix1', 'test_matrix2'):
+            self.assertIn(task_name, result)
+            self.assertDictEqual(expected[task_name], result[task_name])
+        self.assertDictEqual(result, expected)
+
+    def test_rendered_name_matrix(self):
+        """Verify env. values may be used in matrix names with spaces."""
+        test_foobar = dict(env=dict(item="$foo$bar", unique="item"))
+        bar_test = dict(name="$bar test", env=dict(item="${bar}${foo}", NAME="snafu"))
+        task = dict(name="test $item",
+                    env=dict(something="untouched"),
+                    matrix=[bar_test, test_foobar])
+        config = dict(env=self.global_env, blah_task=task)
+        expected = {
+            "test foobar": {
+                "alias": "blah",
+                "env": {
+                    "item": "foobar",
+                    "something": "untouched",
+                    "unique": "item"
+                }
+            },
+            "bar test": {
+                "alias": "blah",
+                "env": {
+                    "NAME": "snafu",
+                    "item": "barfoo",
+                    "something": "untouched"
+                }
+            }
+        }
+        result = self.CCfg(config).tasks
+        self.assertDictEqual(result, expected)
+
+
+class TestCirrusCfg(TestBase):
+    """Fixture to verify loading/parsing from an actual YAML file."""
+
+    def setUp(self):
+        """Initialize before every test."""
+        super().setUp()
+        self.CirrusCfg = self.cci_env.CirrusCfg
+        with open(os.path.join(TEST_DIRPATH, "actual_cirrus.yml")) as actual:
+            self.actual_cirrus = yaml.safe_load(actual)
+
+    def test_complex_cirrus_cfg(self):
+        """Verify that CirrusCfg can be initialized from a complex .cirrus.yml."""
+        with open(os.path.join(TEST_DIRPATH, "expected_cirrus.yml")) as expected:
+            expected_cirrus = yaml.safe_load(expected)
+        actual_cfg = self.CirrusCfg(self.actual_cirrus)
+        self.assertSetEqual(set(actual_cfg.tasks.keys()),
+                            set(expected_cirrus["tasks"].keys()))
+
+    def test_complex_type_image(self):
+        """Verify that CirrusCfg initializes with expected image types and values."""
+        with open(os.path.join(TEST_DIRPATH, "expected_ti.yml")) as expected:
+            expected_ti = yaml.safe_load(expected)
+        actual_cfg = self.CirrusCfg(self.actual_cirrus)
+        self.assertEqual(len(actual_cfg.tasks), len(expected_ti))
+        actual_ti = {k: [v["inst_type"], v["inst_image"]]
+                     for (k, v) in actual_cfg.tasks.items()}
+        self.assertDictEqual(actual_ti, expected_ti)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cirrus-ci_env/test/testbin-cirrus-ci_env.sh
+++ b/cirrus-ci_env/test/testbin-cirrus-ci_env.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Load standardized test harness
+SCRIPT_DIRPATH=$(dirname "${BASH_SOURCE[0]}")
+source ${SCRIPT_DIRPATH}/testlib.sh || exit 1
+
+TEST_DIR=$(realpath "$SCRIPT_DIRPATH/../")
+SUBJ_FILEPATH="$TEST_DIR/${SUBJ_FILENAME%.sh}.py"
+
+test_cmd "Verify no options results in help and an error-exit" \
+    2 "cirrus-ci_env.py: error: the following arguments are required:" \
+    $SUBJ_FILEPATH
+
+test_cmd "Verify missing/invalid filename results in help and an error-exit" \
+    2 "No such file or directory" \
+    $SUBJ_FILEPATH /path/to/not/existing/file.yml \
+
+test_cmd "Verify missing mode-option results in help message and an error-exit" \
+    2 "error: one of the arguments --list --envs --inst is required" \
+    $SUBJ_FILEPATH $SCRIPT_DIRPATH/actual_cirrus.yml
+
+test_cmd "Verify valid-YAML w/o tasks results in help message and an error-exit" \
+    1 "Error: No Cirrus-CI tasks found in" \
+    $SUBJ_FILEPATH --list $SCRIPT_DIRPATH/expected_cirrus.yml
+
+CIRRUS=$SCRIPT_DIRPATH/actual_cirrus.yml
+test_cmd "Verify invalid task name results in help message and an error-exit" \
+    1 "Error: Unknown task name 'foobarbaz' from" \
+    $SUBJ_FILEPATH --env foobarbaz $CIRRUS
+
+TASK_NAMES=$(<"$SCRIPT_DIRPATH/actual_task_names.txt")
+echo "$TASK_NAMES" | while read LINE; do
+    test_cmd "Verify task '$LINE' appears in task-listing output" \
+    0 "$LINE" \
+    $SUBJ_FILEPATH --list $CIRRUS
+done
+
+test_cmd "Verify inherited instance image with env. var. reference is rendered" \
+    0 "container quay.io/libpod/fedora_podman:c6524344056676352" \
+    $SUBJ_FILEPATH --inst 'Ext. services' $CIRRUS
+
+test_cmd "Verify DISTRO_NV env. var renders correctly from test task" \
+    0 'DISTRO_NV="fedora-33"' \
+    $SUBJ_FILEPATH --env 'int podman fedora-33 root container' $CIRRUS
+
+test_cmd "Verify VM_IMAGE_NAME env. var renders correctly from test task" \
+    0 'VM_IMAGE_NAME="fedora-c6524344056676352"' \
+    $SUBJ_FILEPATH --env 'int podman fedora-33 root container' $CIRRUS
+
+exit_with_status

--- a/cirrus-ci_env/test/testlib.sh
+++ b/cirrus-ci_env/test/testlib.sh
@@ -1,0 +1,1 @@
+../../common/test/testlib.sh


### PR DESCRIPTION
The current `get_ci_vm.sh` script is duplicated in each repo with
slight changes, and is therefore difficult to maintain.  This
commit adds a helper script to solve several problems blocking
development of a unified `get_ci_vm.sh`.  Given a (Cirrus-CI
validated) `.cirrus.yml`:

* What is the complete set of task names configured (including matrix
  tasks)
* What environment variables should be set for any given task.
* What kind of runtime instance should be used (i.e. VM or Container)
  for a task.
* What is the VM or container image name to use used for a task

Also, add unit, integration, and system tests for this tool along with
lint and style checking.