### PR TITLE
Fix traceback when task or matrix has no env.

### DIFF
--- a/cirrus-ci_env/cirrus-ci_env.py
+++ b/cirrus-ci_env/cirrus-ci_env.py
@@ -159,7 +159,7 @@ class CirrusCfg:
                                  f" or matrix definition: {item}"
                                  f" for task definition: {task}")
             # default values for the rendered task - not mutable, needs a copy.
-            matrix_task = dict(alias=alias_default, env=task.get("env").copy())
+            matrix_task = dict(alias=alias_default, env=task.get("env", dict()).copy())
             matrix_name = item.get("name", name_default)
             CirrusCfg._working = matrix_name
 

--- a/cirrus-ci_env/test/test_cirrus-ci_env.py
+++ b/cirrus-ci_env/test/test_cirrus-ci_env.py
@@ -165,6 +165,19 @@ class TestRenderTasks(TestBase):
         result = self.CCfg(config).tasks
         self.assertDictEqual(result, expected)
 
+    def test_noenv_render(self):
+        """Verify rendering of task w/o local env. vars."""
+        task = dict(something="ignored")
+        config = dict(env=self.global_env, test_task=task)
+        expected = {
+            "test": {
+                "alias": "test",
+                "env": {}
+            }
+        }
+        result = self.CCfg(config).tasks
+        self.assertDictEqual(result, expected)
+
     def test_simple_matrix(self):
         """Verify unrolling of a simple matrix containing two tasks."""
         matrix1 = dict(name="test_matrix1", env=dict(item="${foo}bar"))
@@ -192,6 +205,22 @@ class TestRenderTasks(TestBase):
         for task_name in ('test_matrix1', 'test_matrix2'):
             self.assertIn(task_name, result)
             self.assertDictEqual(expected[task_name], result[task_name])
+        self.assertDictEqual(result, expected)
+
+    def test_noenv_matrix(self):
+        """Verify unrolling of single matrix w/o env. vars."""
+        matrix = dict(name="test_matrix")
+        task = dict(env=dict(something="untouched"), matrix=[matrix])
+        config = dict(env=self.global_env, test_task=task)
+        expected = {
+            "test_matrix": {
+                "alias": "test",
+                "env": {
+                    "something": "untouched"
+                }
+            }
+        }
+        result = self.CCfg(config).tasks
         self.assertDictEqual(result, expected)
 
     def test_rendered_name_matrix(self):


### PR DESCRIPTION
Signed-off-by: Chris Evich <cevich@redhat.com>