### PR TITLE
[WIP] Skopeo/Buildah/Podman multi-arch image GH actions

### DIFF
--- a/github/actions/multi-arch-build-push/action.yml
+++ b/github/actions/multi-arch-build-push/action.yml
@@ -1,0 +1,56 @@
+---
+
+name: 'Multi-arch container image build and selective push'
+description: |
+    Build container image for multiple architectures,
+    extract version number, then conditionally push
+    to a registry server.
+inputs:
+    registry_namespace:
+        description: 'Registry domain-name, "/", and namespace value for image.'
+        required: true
+    image_name:
+        description: 'Name of image to push (without a tag suffix)'
+        required: true
+    source_name:
+        description: 'Name of build context subdir to use under contrib/<repo>image/'
+        required: true
+    registry_username:
+        description: 'Registry username with access to push images'
+        required: true
+    registry_password:
+        description: 'Registry password corresponding to username'
+        required: true
+    build_arches:
+        description: 'Space separated list of architectures to build'
+        required: true
+        default: "amd64"
+
+runs:
+    # At this time the "composite" type only supports executing multiple
+    # shell steps and not nesting other github actions.
+    using: "composite"
+    steps:
+        - id: setup
+          shell: bash
+          # Unlike EVERY OTHER action type, composite actions must
+          # manually map inputs to env. vars.  Maintain use of the
+          # 'INPUT_' name prefix for consistency with other actions.
+          # Thanks github.
+          # https://github.com/actions/runner/issues/665
+          env:
+              INPUT_REGISTRY_NAMESPACE: ${{ inputs.registry_namespace }}
+              INPUT_IMAGE_NAME: ${{ inputs.image_name }}
+              INPUT_SOURCE_NAME: ${{ inputs.source_name }}
+              INPUT_REGISTRY_USERNAME: ${{ inputs.registry_username }}
+              INPUT_REGISTRY_PASSWORD: ${{ inputs.registry_password }}
+              INPUT_BUILD_ARCHES: ${{ inputs.build_arches }}
+          run: ${{ github.action_path }}/setup.sh
+
+        - id: build
+          shell: bash
+          run: ${{ github.action_path }}/parallel_build.sh
+
+        - id: push
+          shell: bash
+          run: ${{ github.action_path }}/conditional_push.sh

--- a/github/actions/multi-arch-build-push/conditional_push.sh
+++ b/github/actions/multi-arch-build-push/conditional_push.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script is intended to be executed by the `multi-arch-build`
+# github composite action.  Use under any other environment is virtually
+# guaranteed to behave unexpectedly.
+
+set -eo pipefail
+
+source $(dirname "${BASH_SOURCE[0]}")/lib.sh
+
+group_run setup_automation_tooling Setting up automation tooling
+
+group_run load_runtime_environment Loading runtime environment vars
+
+group_run reg_login Login to $INPUT_REGISTRY_NAMESPACE
+
+VERSION=$(get_version)
+FQIN2="${FQIN%%:latest}:$VERSION"
+group_run push_if_new Pushing $FQIN and conditionally $FQIN2

--- a/github/actions/multi-arch-build-push/lib.sh
+++ b/github/actions/multi-arch-build-push/lib.sh
@@ -1,0 +1,243 @@
+
+
+# This library is intended for use by the scripts in this directory.
+# It should not be used directly or by any other scripts.
+
+# Execute some command or function but make github WebUI organize the
+# output inside a handy-dandy expandable section with a title. Ref:
+# https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+group_run() {
+    local ret
+    local command="$1"
+    shift
+    local title="$@"
+    echo "::group::$title"
+    # grouping gets screwed up by stderr output.  Thanks github.
+    if $command &> /dev/stdout; then
+        echo "::endgroup::"
+    else
+        ret=$?
+        echo "::endgroup::"
+        echo "::error::(exit $ret)"
+        return $ret
+    fi
+}
+
+install_automation_tooling() {
+    local install_version="2.1.4"
+    local installer_url="https://raw.githubusercontent.com/containers/automation/master/bin/install_automation.sh"
+    curl --silent --show-error --location \
+         --url "$installer_url" | \
+             env INSTALL_PREFIX=$HOME/.local /bin/bash -s - "$install_version"
+}
+
+setup_automation_tooling() {
+    # defines AUTOMATION_LIB_PATH
+    source $HOME/.local/automation/environment
+    # load all common libraries
+    source $AUTOMATION_LIB_PATH/common_lib.sh
+    # Must be defined after common_lib.sh is loaded
+    SECRET_ENV_RE='(.+PASSWORD.*)|(.+USERNAME.*)'
+}
+
+repo_name() {
+    req_env_vars GITHUB_REPOSITORY
+    cut -d "/" -f 2 <<<"$GITHUB_REPOSITORY"
+}
+
+get_context_dirpath() {
+    req_env_vars GITHUB_WORKSPACE INPUT_SOURCE_NAME
+    printf "%s/%s/%s/\n" \
+        "$GITHUB_WORKSPACE/contrib" \
+        $(repo_name)image \
+        "$INPUT_SOURCE_NAME"
+}
+
+verify_runtime_environment() {
+    req_env_vars CI GITHUB_ACTIONS GITHUB_REPOSITORY GITHUB_SHA GITHUB_ACTION_PATH
+    req_env_vars INPUT_REGISTRY_NAMESPACE INPUT_IMAGE_NAME INPUT_SOURCE_NAME
+    req_env_vars INPUT_REGISTRY_USERNAME INPUT_REGISTRY_PASSWORD INPUT_BUILD_ARCHES
+
+    # Only "Composite" github actions define GITHUB_ACTION_PATH, this is required
+    # because we will be using container tooling, which cannot run properly inside
+    # a container (the normal environment for github actions).
+    if  [[ "$CI" != "true" ]] || \
+        [[ "$GITHUB_ACTIONS" != "true" ]] || \
+        [[ ! -d "$GITHUB_ACTION_PATH" ]]
+    then
+        die "This script must be run as a github composite action"
+    fi
+    msg "Runtime environment appears as expected"
+
+    # Dump required action input variables into a file so they don't need to be
+    # duplicated over and over in action.yml (YAML anchors/aliases not supported).
+    cat << EOF > $HOME/.local/automation/runtime
+# Automatically generated file, do not edit, any/all changes will be overwritten.
+INPUT_REGISTRY_NAMESPACE="$INPUT_REGISTRY_NAMESPACE"
+INPUT_IMAGE_NAME="$INPUT_IMAGE_NAME"
+INPUT_SOURCE_NAME="$INPUT_SOURCE_NAME"
+INPUT_REGISTRY_USERNAME="$INPUT_REGISTRY_USERNAME"
+INPUT_REGISTRY_PASSWORD="$INPUT_REGISTRY_PASSWORD"
+INPUT_BUILD_ARCHES="$INPUT_BUILD_ARCHES"
+BUILDCTX=$(get_context_dirpath)
+BUILDTMP="$(mktemp -d -p '' tmp_$(basename $0)_XXXXXXXX)"
+FQIN="$INPUT_REGISTRY_NAMESPACE/$INPUT_IMAGE_NAME:latest"
+EOF
+}
+
+load_runtime_environment() {
+    source $HOME/.local/automation/runtime
+    req_env_vars FQIN
+    # For filesystem names, need to replace problematic characters
+    _FQIN=$(tr -d '[:space:]' <<<"$FQIN" | tr -c '[:alnum:]' '_')
+}
+
+# Register QEMU to handle non-native execution
+# Ref: https://github.com/multiarch/qemu-user-static#multiarchqemu-user-static-images
+setup_qemu_binfmt() {
+    local bin_vols
+    # TODO: Copy this image over to quay to avoid pull-throttling surprises
+    local qemu_setup_fqin="docker.io/multiarch/qemu-user-static"
+    sudo apt-get update -qq -y
+    sudo apt-get install -qq -y qemu-user-static
+    # Register binaries the host actually has available
+    bin_vols=$(find /usr/bin -name 'qemu-*-static' | awk '{print "-v "$1":"$1}' | tr '\n' ' ')
+    # This has to run as root and --privileged since it modifies the kernel
+    # sysctl's and loads the interpreter binaries persistently into memory.
+    sudo podman run --rm --privileged $bin_vols $qemu_setup_fqin --reset -p yes
+}
+
+tooling_versions() {
+    skopeo --version
+    buildah version
+    podman version
+}
+
+build_image_arch() {
+    req_env_vars arch BUILDCTX BUILDTMP GITHUB_REPOSITORY GITHUB_SHA
+    local arch_fqin
+    local tmp_root
+    local tmp_run
+    # Docs indicate source image must be tagged for addition into a manifest
+    arch_fqin="${FQIN%%:latest}:$arch"
+    # Assuming builds are running in parallel for multiple architectures,
+    # it's possible for storage clashes to occur when pulling the base image.
+    # Guarantee this cannot happen by performing each build in a dedicated
+    # storage root.
+    tmp_root=$(mktemp -d -p "$BUILDTMP" "${arch}_root_XXXXXXXX")
+    tmp_run=$(mktemp -d -p "$BUILDTMP" "${arch}_run_XXXXXXXX")
+
+    echo "Building $arch_fqin using $BUILDCTX"
+    podman \
+        --root=$tmp_root \
+        --runroot=$tmp_run \
+        build \
+        --no-cache \
+        --arch=$arch \
+        --tag=$arch_fqin \
+        --label "org.opencontainers.image.source=https://github.com/$GITHUB_REPOSITORY.git" \
+        --label "org.opencontainers.image.revision=$GITHUB_SHA" \
+        --label "org.opencontainers.image.created=$(date -u --iso-8601=seconds)" \
+        "$BUILDCTX"
+
+    echo "Migrating built image from sequestered to main storage"
+    podman \
+        --root=$tmp_root \
+        --runroot=$tmp_run \
+        save \
+        --quiet \
+        --format=docker-archive \
+        --output="$BUILDTMP/images/${arch}_img.tar" \
+        $arch_fqin
+
+    # Later, image will be executed to obtain version information
+    podman load --quiet --input="$BUILDTMP/images/${arch}_img.tar"
+
+    echo "Cleaning up sequestered build storage"
+    sudo rm -rf "$tmp_root" "$tmp_run"
+}
+
+combine_images() {
+    local arch
+    local arch_fqin
+    req_env_vars FQIN
+    for arch in $INPUT_BUILD_ARCHES; do
+        arch_fqin="${FQIN%%:latest}:$arch"
+        msg "Adding $arch_fqin..."
+        # Careful, the option order is: <list> <image>
+        # N/B: Images _MUST_ be added to manifest from a docker-archive
+        # file.  Using containers-storage image will strip out non-native
+        # architecture layers.
+        podman manifest add --all \
+            "$FQIN" \
+            "docker-archive:$BUILDTMP/images/${arch}_img.tar"
+    done
+    echo "Image manifest contents:"
+    podman manifest inspect $FQIN | jq --color-output .
+}
+
+get_version() {
+    req_env_vars FQIN
+    local stdout
+    local version_cmd
+    local version
+    case $(repo_name) in
+        skopeo) version_cmd="--version" ;;  # image sets entrypoint
+        buildah) version_cmd="podman --storage-driver=vfs version" ;;
+        podman) version_cmd="buildah --storage-driver=vfs version" ;;
+        *) die "Unknown/unhandled repository '$(repo_name)'"
+    esac
+    msg "Executing '$version_cmd'"
+    stdout=$(podman run -i --rm $FQIN bash -c "$version_cmd")
+    msg "Output:
+$stdout"
+    version=$(grep -Eim1 '^version:[[:space:]]+' <<<"$stdout" | awk '{print $2}')
+    test -n "$version"
+    msg "Found version '$version'"
+    echo "$version"
+}
+
+get_existing_tags() {
+    req_env_vars FQIN
+    local existing_tags
+    existing_tags=$(skopeo list-tags \
+        docker://${FQIN%%:latest} | \
+        jq -r '.Tags[]')
+    msg "Existing tags:
+$existing_tags"
+    test -n "$existing_tags"
+    echo "$existing_tags"
+}
+
+reg_login() {
+    req_env_vars INPUT_REGISTRY_NAMESPACE INPUT_REGISTRY_USERNAME INPUT_REGISTRY_PASSWORD
+    # At the time of implementation, for an unknown reason, skopeo isn't using
+    # the correct auth file, but buildah/podman are fine.  Work around this by
+    # forcing a specific file location.
+    export REGISTRY_AUTH_FILE=$HOME/auth.json
+    echo "$INPUT_REGISTRY_PASSWORD" | \
+        skopeo login --username "$INPUT_REGISTRY_USERNAME" --password-stdin \
+        "$INPUT_REGISTRY_NAMESPACE"
+}
+
+push_if_new() {
+    local existing_tags
+    req_env_vars VERSION FQIN FQIN2
+
+    echo "::warning::Pushing to $FQIN"
+    podman push $FQIN
+
+    existing_tags=$(get_existing_tags)
+    if [[ -z "$existing_tags" ]]; then
+        die "Retrieved empty tag list, is this a new registry/image?"
+    fi
+
+    if ! fgrep -qx "$VERSION" <<<"$existing_tags";
+    then  # A new version was built
+        echo "::warning::Pushing to $FQIN2"
+        podman tag $FQIN $FQIN2
+        podman push $FQIN2
+    else
+        echo "Found existing tag $VERSION, not pushing."
+    fi
+}

--- a/github/actions/multi-arch-build-push/parallel_build.sh
+++ b/github/actions/multi-arch-build-push/parallel_build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This script is intended to be executed by the `multi-arch-build`
+# github composite action.  Use under any other environment is virtually
+# guaranteed to behave unexpectedly.
+
+set -eo pipefail
+
+source $(dirname "${BASH_SOURCE[0]}")/lib.sh
+
+group_run setup_automation_tooling Setting up automation tooling
+
+group_run load_runtime_environment Loading runtime environment vars
+
+group_run "podman manifest create $FQIN" Create manifest image for $FQIN
+
+# Every arch needs to download/install potentially many packages.
+# Improve overall runtime by allowing this to execute in parallel.
+declare -a jobs
+for arch in $INPUT_BUILD_ARCHES; do
+    build_image_arch > "/tmp/build_${arch}_${_FQIN}.log" 2>&1 &
+    jid="$!"
+    msg "Building $FQIN for $arch as job $jid"
+    # Track job IDs + arch to provide status info.
+    jobs+=("$jid,$arch")
+done
+
+msg "Waiting for builds to complete..."
+something_broke=0
+for jid_arch in ${jobs[*]}; do
+    jid=$(cut -d "," -f 1 <<<"$jid_arch")
+    arch=$(cut -d "," -f 2 <<<"$jid_arch")
+    word=""
+    if wait $jid; then
+        word="successful"
+    else
+        word="failed (exit $?)"
+        something_broke=1
+    fi
+    group_run "cat /tmp/build_${arch}_${_FQIN}.log" "Job $jid for $arch build of $FQIN $word."
+done
+
+if ((something_broke)); then
+    die "At least one build failed, not continuing"
+fi
+
+group_run combine_images "Combining all images into $FQIN manifest"

--- a/github/actions/multi-arch-build-push/setup.sh
+++ b/github/actions/multi-arch-build-push/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This script is intended to be executed by the `multi-arch-build`
+# github composite action.  Use under any other environment is virtually
+# guaranteed to behave unexpectedly.
+
+set -eo pipefail
+
+source $(dirname "${BASH_SOURCE[0]}")/lib.sh
+
+# Make sure these values are masked in the output...by printing them to output,
+# which isn't weird or prone to bugs/accidents.  Thanks github.
+echo "::add-mask::$INPUT_REGISTRY_USERNAME"
+echo "::add-mask::$INPUT_REGISTRY_PASSWORD"
+
+group_run install_automation_tooling Install common automation tooling libraries
+
+group_run setup_automation_tooling Setting up automation tooling
+
+group_run show_env_vars Environment Variables
+
+group_run tooling_versions Podman, Buildah, and Skopeo versions
+
+group_run verify_runtime_environment Verify environment expectations
+
+group_run load_runtime_environment Loading runtime environment vars
+
+msg "Creating directory for arch-image exports:"
+mkdir -vp "$BUILDTMP/images"
+
+group_run setup_qemu_binfmt Configure QEMU for execution of non-native binaries

--- a/github/actions/registry_details/action.sh
+++ b/github/actions/registry_details/action.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This script is intended to be executed by the `registry_details`
+# github composite action.  Use under any other environment is virtually
+# guaranteed to behave unexpectedly.
+
+set -eo pipefail
+
+# For human readability, reference input variable name used
+# in the workflow, not the mangled action variable name.
+inp_var_name() {
+    echo -n $(tr "[A-Z]" "[a-z]" <<<"${1#INPUT_}")
+}
+
+req_inp_vars() {
+    local var
+    local val
+    for var in "$@"; do
+        val=$(tr -d "[:space:]" <<<"${!var}")
+        if [[ -z "${val}" ]]; then
+            echo "::error::Input variable '$(inp_var_name $var)' must not be empty or whitespace."
+            exit 1
+        fi
+    done
+}
+
+req_inp_vars INPUT_SOURCE_NAME INPUT_SECRET_PREFIX \
+             INPUT_REPONAME_QUAY_USERNAME INPUT_REPONAME_QUAY_PASSWORD \
+             INPUT_CONTAINERS_QUAY_USERNAME INPUT_CONTAINERS_QUAY_PASSWORD
+
+reponame=$(cut -d "/" -f 2 <<<"$GITHUB_REPOSITORY")
+username_varname="INPUT_${INPUT_SECRET_PREFIX}_QUAY_USERNAME"
+password_varname="INPUT_${INPUT_SECRET_PREFIX}_QUAY_PASSWORD"
+
+case "$INPUT_SECRET_PREFIX" in
+  REPONAME)
+      echo "Will operate on 'quay.io/$reponame/$INPUT_SOURCE_NAME'"
+      echo "::set-output name=namespace::quay.io/$reponame"
+      echo "::set-output name=image_name::$INPUT_SOURCE_NAME"
+      ;;
+  CONTAINERS)
+      echo "Will operate on 'quay.io/containers/$reponame'"
+      echo "::set-output name=namespace::quay.io/containers"
+      echo "::set-output name=image_name::$reponame"
+      ;;
+  *)
+      echo "::error::Unknown secret_prefix '$INPUT_SECRET_PREFIX'"
+      exit 1
+      ;;
+esac
+
+username="${!username_varname}"
+password="${!password_varname}"
+echo "Getting username from $(inp_var_name $username_varname), password from $(inp_var_name $password_varname)"
+echo "::set-output name=username::$username"
+echo "::set-output name=password::$password"

--- a/github/actions/registry_details/action.yml
+++ b/github/actions/registry_details/action.yml
@@ -1,0 +1,51 @@
+---
+
+name: 'Registry namespace, image name, and login details lookup'
+description: |
+    Set output values for 'namespace', 'image_name', 'username', and 'password'
+    based upon the 'secret_prefix' value and repository name.
+inputs:
+    source_name:
+        description: 'Image build subdirectory name (upstream, testing, or stable)'
+    secret_prefix:
+        description: 'Prefix to the _QUAY_USERNAME and _QUAY_PASSWORD github secret names'
+        required: true
+    reponame_quay_username:
+        description: 'Registry login username for the repository quay robot account.'
+        required: true
+    reponame_quay_password:
+        description: 'Registry login password for the repository quay robot account.'
+        required: true
+    containers_quay_username:
+        description: 'Registry login username for the containers quay robot account.'
+        required: true
+    containers_quay_password:
+        description: 'Registry login password for the containers quay robot account.'
+        required: true
+outputs:
+    namespace:
+        value: ${{ steps.lookup.outputs.namespace }}
+    image_name:
+        value: ${{ steps.lookup.outputs.image_name }}
+    username:
+        value: ${{ steps.lookup.outputs.username }}
+    password:
+        value: ${{ steps.lookup.outputs.password }}
+runs:
+    using: "composite"
+    steps:
+        - id: lookup
+          shell: bash
+          # Unlike EVERY OTHER action type, composite actions must
+          # manually map inputs to env. vars.  Maintain use of the
+          # 'INPUT_' name prefix for consistency with other actions.
+          # Thanks github.
+          # https://github.com/actions/runner/issues/665
+          env:
+              INPUT_SOURCE_NAME: ${{ inputs.source_name }}
+              INPUT_SECRET_PREFIX: ${{ inputs.secret_prefix }}
+              INPUT_REPONAME_QUAY_USERNAME: ${{ inputs.reponame_quay_username }}
+              INPUT_REPONAME_QUAY_PASSWORD: ${{ inputs.reponame_quay_password }}
+              INPUT_CONTAINERS_QUAY_USERNAME: ${{ inputs.containers_quay_username }}
+              INPUT_CONTAINERS_QUAY_PASSWORD: ${{ inputs.containers_quay_password }}
+          run: ${{ github.action_path }}/action.sh


### PR DESCRIPTION
The `repository_details` action helps look up the proper
secret env. vars and repository namespace details based
on the workflow's matrix-item inputs.  In other words
it allows the build & push action (below) to push to multiple
image repositories without being concerned with the login
or namespace details.

The `multi-arch-build-push` action builds a Skopeo, Buildah,
or Podman image for multiple architectures.  If successful,
it is pushed as 'latest' to a repository namespace.  It then
obtains the skopeo|buildah|podman version number, and conditionally
pushes if a version-tagged image does not already exist.

Signed-off-by: Chris Evich <cevich@redhat.com>