### PR TITLE
Fix /dev/stderr: permission denied

### DIFF
--- a/bin/install_automation.sh
+++ b/bin/install_automation.sh
@@ -40,7 +40,7 @@ _ARGS="$@"
 _MAGIC_JUJU=${_MAGIC_JUJU:-XXXXX}
 _DEFAULT_MAGIC_JUJU=d41d844b68a14ee7b9e6a6bb88385b4d
 
-msg() { echo -e "${1:-No Message given}" > /dev/stderr; }
+msg() { echo -e "${1:-No Message given}"; }
 
 dbg() { if ((DEBUG)); then msg "\n# $1"; fi }
 
@@ -202,7 +202,7 @@ exec_installer() {
             _MAGIC_JUJU="$_DEFAULT_MAGIC_JUJU" \
             /bin/bash "$DOWNLOADED_INSTALLER" "$version_arg" $_ARGS
     else
-        msg "Error: '$DOWNLOADED_INSTALLER' does not exist or is not executable" > /dev/stderr
+        msg "Error: '$DOWNLOADED_INSTALLER' does not exist or is not executable"
         # Allow exi
         exit 8
     fi
@@ -273,7 +273,7 @@ elif [[ "$_MAGIC_JUJU" == "$_DEFAULT_MAGIC_JUJU" ]]; then
         echo -n "##### Finalizing successful installation of version "
         echo -n "$AUTOMATION_VERSION" | tee "$AUTOMATION_LIB_PATH/../AUTOMATION_VERSION"
         echo " of 'common'${_ARGS:+,  and subcomponents: $_ARGS}"
-    ) > /dev/stderr
+    )
 else # Something has gone horribly wrong
     msg "Error: The installer script is incompatible with version $AUTOMATION_VERSION"
     msg "Please obtain and use a newer version of $SCRIPT_FILENAME which supports ID $_MAGIC_JUJU"

--- a/common/test/testbin-install_automation.sh
+++ b/common/test/testbin-install_automation.sh
@@ -64,6 +64,11 @@ test_cmd \
     0 "$(git describe HEAD)" \
     cat "$INSTALL_PREFIX/automation/AUTOMATION_VERSION"
 
+test_cmd \
+    "The installer script doesn't redirect to 'stderr' anywhere." \
+    1 "" \
+    grep -q '> /dev/stderr' $INSTALLER_FILEPATH
+
 load_example_environment() {
     local _args="$@"
     # Don't disturb testing


### PR DESCRIPTION
Under some execution contexts (i.e. `sudo`), under some flavors of bash,
these special device files may not be accessable.  Refrain from using
them during the install process.

Signed-off-by: Chris Evich <cevich@redhat.com>