### PR TITLE
Fix master branch reference

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@
 # Global environment variables
 env:
     # Name of the typical destination branch for PRs.
-    DEST_BRANCH: "master"
+    DEST_BRANCH: "main"
 
 
 # Default task runtime environment
@@ -49,7 +49,7 @@ github-actions/success_task:
     #       to the action itself.
     trigger_type: manual
     # Only required for PRs, never tag or branch testing
-    only_if: $CIRRUS_BRANCH != $DEST_BRANCH
+    only_if: $CIRRUS_PR =~ '.*[0-9]+.*'
     depends_on:
         - cirrus-ci/test
     clone_script: mkdir -p "$CIRRUS_WORKING_DIR"


### PR DESCRIPTION
The branch was renamed long ago, but this change was missed due to the
only check using it was negative.  Fix this so it's easier to understand
the task which should only run in PRs.

Signed-off-by: Chris Evich <cevich@redhat.com>