### PR TITLE
Fix exports

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,9 +45,7 @@ cirrus-ci/build-push_test_task:
         image_family: centos-stream-8
     timeout_in: 20
     env:
-        # Need buildah version 1.23 or later (unreleased as of this commit)
-        # TODO: Use a version-tagged image when avail for CI-stability.
-        CIMG: quay.io/buildah/upstream:latest
+        CIMG: quay.io/buildah/stable:v1.23.0
         TEST_FQIN: quay.io/buildah/do_not_use
         # Robot account credentials for test-push to
         # $TEST_FQIN registry by build-push/test/testbuilds.sh

--- a/build-push/test/fake_buildah.sh
+++ b/build-push/test/fake_buildah.sh
@@ -1,3 +1,21 @@
 #!/bin/bash
 
-echo "$@"
+if [[ "$1" == "manifest" ]]; then
+    cat <<EOF
+{"manifests":[
+    {"platform":{"architecture":"amd64"}},
+    {"platform":{"architecture":"correct"}},
+    {"platform":{"architecture":"horse"}},
+    {"platform":{"architecture":"battery"}},
+    {"platform":{"architecture":"staple"}}
+]}
+EOF
+elif [[ "$1" =~ info ]]; then
+    case "$@" in
+        *arch*) echo "amd64" ;;
+        *cpus*) echo "2" ;;
+        *) exit 1 ;;
+    esac
+else
+    echo "FAKEBUILDAH $@"
+fi


### PR DESCRIPTION
It's necessary for downstream usage that both a --modcmd and --prepcmd
script have access to the parsed value from --arches.  Prior to this
commit, the value was stored in an array.  Unf., many versions of bash
do not yet support export of array variables.  This commit converts it
into a simple space-separated string and adds a test to confirm.

While fixing this, it was discovered that the handling of \$BUILD_ARGS
was also wrong.  Both quoting and any use of embedded special characters
(like whitespace) would not be preserved.  It was also marked as a
variable exported to to --prep/--modcmd, which is not possible.  Fix
this by removing it from the export list, and tweak the processing and
use of \$BUILD_ARGS in general.  Add a test to confirm proper handling
of both quotes and special characters.

Lastly, some seemingly unrelated changes were made to simplify the
addition of the above tests.