### PR TITLE
Fix automatic inclusion of local arch

### DIFF
--- a/build-push/bin/build-push.sh
+++ b/build-push/bin/build-push.sh
@@ -194,7 +194,7 @@ parse_args() {
             --arches=*)
                 archarg=$(tr ',' ' '<<<"${arg:9}")
                 if [[ -z "$archarg" ]]; then die_help "$E_ONEARCH '$arg'"; fi
-                ARCHES="$ARCHES $archarg"
+                ARCHES="$archarg"
                 ;;
             --arches)
                 # Argument format not supported (to simplify parsing logic)
@@ -335,6 +335,7 @@ confirm_arches() {
     req_env_vars FQIN ARCHES RUNTIME
     maniarches=$($RUNTIME manifest inspect "containers-storage:$FQIN:latest" | \
                  jq -r "$filter" | \
+                 grep -v 'null' | \
                  tr -s '[:space:]' ' ' | \
                  sed -z '$ s/[\n ]$//')
     dbg "Found manifest arches: $maniarches"

--- a/build-push/test/fake_buildah.sh
+++ b/build-push/test/fake_buildah.sh
@@ -1,15 +1,34 @@
 #!/bin/bash
 
-if [[ "$1" == "manifest" ]]; then
-    cat <<EOF
-{"manifests":[
-    {"platform":{"architecture":"amd64"}},
-    {"platform":{"architecture":"correct"}},
-    {"platform":{"architecture":"horse"}},
-    {"platform":{"architecture":"battery"}},
-    {"platform":{"architecture":"staple"}}
-]}
-EOF
+set -e
+
+# Need to keep track of values from 'build' to 'manifest' calls
+DATF='/tmp/fake_buildah.json'
+
+if [[ "$1" == "build" ]]; then
+    echo '{"manifests":[' > $DATF
+    for arg; do
+        if [[ "$arg" =~ --platform= ]]; then
+            for platarch in $(cut -d '=' -f 2 <<<"$arg" | tr ',' ' '); do
+                arch=$(cut -d '/' -f 2 <<<"$platarch")
+                [[ -n "$arch" ]] || continue
+                echo "FAKEBUILDAH ($arch)" > /dev/stderr
+                echo -n '    {"platform":{"architecture":"' >> $DATF
+                echo -n "$arch" >> $DATF
+                echo '"}},' >> $DATF
+            done
+        fi
+    done
+    # dummy-value to avoid dealing with JSON oddity: last item must not
+    # end with a comma
+    echo '    {}' >> $DATF
+    echo ']}' >> $DATF
+
+    # Tests expect to see this
+    echo "FAKEBUILDAH $@"
+elif [[ "$1" == "manifest" ]]; then
+    # validate json while outputing it
+    jq . $DATF
 elif [[ "$1" =~ info ]]; then
     case "$@" in
         *arch*) echo "amd64" ;;
@@ -17,5 +36,6 @@ elif [[ "$1" =~ info ]]; then
         *) exit 1 ;;
     esac
 else
-    echo "FAKEBUILDAH $@"
+    echo "ERROR: Unexpected call to fake_buildah.sh"
+    exit 9
 fi

--- a/build-push/test/testbin-build-push.sh
+++ b/build-push/test/testbin-build-push.sh
@@ -79,7 +79,7 @@ test_cmd "Verify non-numeric \$PARALLEL_JOBS is handled properly" \
 
 PREPCMD='echo "#####${ARCHES}#####"'
 test_cmd "Verify \$ARCHES value is available to prep-command" \
-    0 "#####amd64 correct horse battery staple#####.+FAKEBUILDAH.+test_context" \
+    0 "#####correct horse battery staple#####.+FAKEBUILDAH.+test_context" \
     bash -c "$SUBJ_FILEPATH --arches=correct,horse,battery,staple localhost/foo/bar --nopush --prepcmd='$PREPCMD' $TEST_CONTEXT 2>&1"
 
 rx="FAKEBUILDAH build \\$'--test-build-arg=one \\\"two\\\" three\\\nfour' --anotherone=foo\\\ bar"


### PR DESCRIPTION
When executing build-push.sh with the `--arches=*` option, the script
automatically includes the local architecture by default.  This may
be counter-intuitive and is contrary to the documentation for this
option.  Worse, if the local architecture is specified as an
`--arches` argument, buildah will build TWO images for it. Fix this
by excluding the default local-arch value when processing the
`--arches` command-line option.

Signed-off-by: Chris Evich <cevich@redhat.com>