### PR TITLE
Fix cirrus-ci_retrospective image missing python3

### DIFF
--- a/cirrus-ci_retrospective/Dockerfile
+++ b/cirrus-ci_retrospective/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora-minimal:latest
 RUN microdnf update -y && \
-    microdnf install -y findutils jq git curl && \
+    microdnf install -y findutils jq git curl python3 && \
     microdnf clean all && \
     rm -rf /var/cache/dnf
 # Assume build is for development/manual testing purposes by default (automation should override with fixed version)


### PR DESCRIPTION
Fixes https://github.com/containers/automation/runs/5425690658?check_suite_focus=true#step:4:12

Signed-off-by: Chris Evich <cevich@redhat.com>