### PR TITLE
Make /etc/automation_environment easier to consume

### DIFF
--- a/bin/install_automation.sh
+++ b/bin/install_automation.sh
@@ -127,8 +127,8 @@ install_automation() {
     cat <<EOF>"$INSTALLATION_SOURCE/environment"
 # Added on $(date --iso-8601=minutes) by $actual_inst_path/bin/$SCRIPT_FILENAME"
 # Any manual modifications will be lost upon upgrade or reinstall.
-AUTOMATION_LIB_PATH="$actual_inst_path/lib"
-PATH="$PATH:$actual_inst_path/bin"
+export AUTOMATION_LIB_PATH="$actual_inst_path/lib"
+export PATH="$PATH:$actual_inst_path/bin"
 EOF
 }
 

--- a/github/.install.sh
+++ b/github/.install.sh
@@ -27,6 +27,6 @@ install -v $INST_PERM_ARG -D -t "$INSTALL_PREFIX/lib" ./lib/*
 # Needed for installer testing
 cat <<EOF>>"./environment"
 # Added on $(date --iso-8601=minutes) by 'github' subcomponent installer
-GITHUB_ACTION_LIB=$INSTALL_PREFIX/lib/github.sh
+export GITHUB_ACTION_LIB=$INSTALL_PREFIX/lib/github.sh
 EOF
 echo "Successfully installed $INSTALL_NAME"


### PR DESCRIPTION
In nearly all use-cases, users of the automation libraries/tools need to
both load and export variables in this file.  Otherwise loading
additional libraries (which depend on the variables) will fail.  Make
this easier on downstream users by exporting important variables in-line
in this file.

Signed-off-by: Chris Evich <cevich@redhat.com>