### PR TITLE
Fix overly inclusive error check

### DIFF
--- a/cirrus-ci_retrospective/lib/cirrus-ci_retrospective.sh
+++ b/cirrus-ci_retrospective/lib/cirrus-ci_retrospective.sh
@@ -99,7 +99,7 @@ filter_json() {
     dbg "### Validating JSON in '$json_file'"
     # Confirm input json is valid and make filter problems easier to debug (below)
     local tmp_json_file=$(tmpfile json)
-    if ! jq . < "$json_file" > "$tmp_json_file"; then
+    if ! jq -e . < "$json_file" > "$tmp_json_file"; then
         rm -f "$tmp_json_file"
         # JQ has already shown an error message
         die "Error from jq relating to JSON: $(cat $json_file)"
@@ -146,11 +146,6 @@ url_query_filter_test() {
     dbg "## Curl output file: $curl_outputf)"
     [[ "$ret" -eq "0" ]] || \
         die "Curl command exited with non-zero code: $ret"
-
-    if grep -q "error" "$curl_outputf"; then
-        # Barely passable attempt to catch GraphQL query errors
-        die "Found the word 'error' in curl output: $(cat $curl_outputf)"
-    fi
 
     # Validates both JSON and filter, updates $curl_outputf
     filter_json "$filter" "$curl_outputf"


### PR DESCRIPTION
Should a GraphQL query not satisfy the schema, the server will
frequently return a JSON formatted error message.  The
cirrus-ci_retrospective library checks for this by using a naive
`grep` command.  However, this could mistakenly trigger on the `error`
term naturally appearing in a non-error/valid response.  Remove this
check.  Instead, enhance the existing `filter_json()` checks by
causing jq to exit non-zero for invalid JSON replies.  Assume callers
of cirrus-ci_retrospective will be sensitive to an error reply from
the server, and handle it accordingly.

Signed-off-by: Chris Evich <cevich@redhat.com>