### PR TITLE
Add parser support for windows container tasks

### DIFF
--- a/cirrus-ci_env/test/actual_cirrus.yml
+++ b/cirrus-ci_env/test/actual_cirrus.yml
@@ -732,6 +732,22 @@ success_task:
     clone_script: *noop
     script: /bin/true
 
+win_installer_task:
+    name: "Verify Win Installer Build"
+    alias: win_installer
+    # Don't run for multiarch container image cirrus-cron job.
+    only_if: $CIRRUS_CRON != 'multiarch'
+    depends_on:
+      - alt_build
+    windows_container:
+        image: "cirrusci/windowsservercore:2019"
+    env:
+        PATH: "${PATH};C:\\ProgramData\\chocolatey\\bin"
+        CIRRUS_SHELL: powershell
+        # Fake version, we are only testing the installer functions, so version doesn't matter
+        WIN_INST_VER: 9.9.9
+    install_script: '.\contrib\cirrus\win-installer-install.ps1'
+    main_script: '.\contrib\cirrus\win-installer-main.ps1'
 
 # When a new tag is pushed, confirm that the code and commits
 # meet criteria for an official release.

--- a/cirrus-ci_env/test/actual_task_names.txt
+++ b/cirrus-ci_env/test/actual_task_names.txt
@@ -25,6 +25,7 @@ Upgrade test: from v2.1.1
 VM img. keepalive
 Validate fedora-33 Build
 Verify Release
+Verify Win Installer Build
 Windows Cross
 compose test on fedora-33
 int podman fedora-33 root container

--- a/cirrus-ci_env/test/expected_cirrus.yml
+++ b/cirrus-ci_env/test/expected_cirrus.yml
@@ -259,6 +259,12 @@ tasks:
       TEST_FLAVOR: release
       VM_IMAGE_NAME: fedora-c6524344056676352
       _BUILD_CACHE_HANDLE: fedora-33-build-${CIRRUS_BUILD_ID}
+  Verify Win Installer Build:
+    alias: win_installer
+    env:
+      PATH: "${PATH};C:\\ProgramData\\chocolatey\\bin"
+      CIRRUS_SHELL: powershell
+      WIN_INST_VER: 9.9.9
   Windows Cross:
     alias: alt_build
     env:

--- a/cirrus-ci_env/test/expected_ti.yml
+++ b/cirrus-ci_env/test/expected_ti.yml
@@ -80,6 +80,9 @@ Validate fedora-33 Build:
 Verify Release:
 - gcevm
 - fedora-c6524344056676352
+Verify Win Installer Build:
+- wincntnr
+- cirrusci/windowsservercore:2019
 Windows Cross:
 - gcevm
 - fedora-c6524344056676352

--- a/cirrus-ci_env/test/test_cirrus-ci_env.py
+++ b/cirrus-ci_env/test/test_cirrus-ci_env.py
@@ -290,6 +290,7 @@ class TestCirrusCfg(TestBase):
         self.assertEqual(len(actual_cfg.tasks), len(expected_ti))
         actual_ti = {k: [v["inst_type"], v["inst_image"]]
                      for (k, v) in actual_cfg.tasks.items()}
+        self.maxDiff = None  # show the full dif
         self.assertDictEqual(actual_ti, expected_ti)
 
 


### PR DESCRIPTION
Also fix attempts to expand `$PATH`, this variable is handled specially by Cirrus-CI so it can just be ignored.