### PR TITLE
Rename GHA jobs to remove ambiguity

### DIFF
--- a/.github/workflows/action_helper_test.yml
+++ b/.github/workflows/action_helper_test.yml
@@ -16,7 +16,7 @@ env:
     ACTIONS_STEP_DEBUG: '${{ secrets.ACTIONS_STEP_DEBUG }}'
 
 jobs:
-    unit-test:
+    helper_unit-test:
         runs-on: ubuntu-latest
         steps:
             - name: Clone the repository code

--- a/.github/workflows/ubuntu_unit_tests.yml
+++ b/.github/workflows/ubuntu_unit_tests.yml
@@ -1,9 +1,9 @@
 ---
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
-    unit-tests:
+    automation_unit-tests:
         runs-on: ubuntu-20.04
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
There are several jobs called `unit-tests`.  Rename them with a prefix to clarify exactly what they're testing.  Also, add a run of the (renamed) `automation_unit-tests` to happen at branch-push time.

Signed-off-by: Chris Evich <cevich@redhat.com>