### PR TITLE
Redirect default JSON config to path'd JSON5 config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,8 +36,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   // Re-use predefined sets of configuration options to DRY
   "extends": [
-    // https://github.com/containers/automation/blob/main/default.json
-    "github>containers/automation"
+    // https://github.com/containers/automation/blob/main/renovate/defaults.json5
+    "github>containers/automation//renovate/defaults.json5"
   ],
   /*************************************************
    *** Repository-specific configuration options ***

--- a/default.json
+++ b/default.json
@@ -1,12 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":preserveSemverRanges",
-    ":gitSignOff",
-    ":rebaseStalePrs",
-    "schedule:weekly"
-  ],
-  "prHourlyLimit": 1,
-  "labels": ["dependencies_update"]
+    "github>containers/automation//renovate/defaults.json5"
+  ]
 }

--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "description": "This is a basic preset intended\
+  for reuse to reduce the amount of boiler-plate\
+  configuration that otherwise would need to be\
+  duplicated.  The default-preset for this repository\
+  redirects here (because json5 cannot be used in the\
+  default).  It should be referenced by other configs.\
+  under the 'extends' section as:\
+  github>containers/automation",
+
+  /*************************************************
+   ****** Global/general configuration options *****
+   *************************************************/
+
+  // Re-use predefined sets of configuration options to DRY
+  "extends": [
+    // https://docs.renovatebot.com/presets-config/#configbase
+    "config:base",
+
+    // https://docs.renovatebot.com/presets-default/#preservesemverranges
+    ":preserveSemverRanges",
+
+    // https://docs.renovatebot.com/presets-default/#gitsignoff
+    ":gitSignOff",
+
+    // Always rebase dep. update PRs from `main` when PR is stale
+    ":rebaseStalePrs",
+
+    // https://docs.renovatebot.com/presets-schedule/#scheduleweekly
+    "schedule:weekly",
+  ],
+
+  // Don't swamp CI, rate-limit opening of PRs w/in schedule limits.
+  "prHourlyLimit": 1,
+
+  // Make renovate PRs stand out from the crowd
+  "labels": ["dependencies_update"],
+}


### PR DESCRIPTION
JSON5 is far more readable, but cannot be used for the default. Workaround this by referencing a JSON5 preset from the default JSON preset.

Signed-off-by: Chris Evich <cevich@redhat.com>