### PR TITLE
Separate out packageRules from golang config object

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -70,35 +70,35 @@ Validate this file before commiting with (from repository root):
     // In case a version in use is retracted, allow going backwards.
     // N/B: This is NOT compatible with pseudo versions, see below.
     "rollbackPrs": false,
-
-    // N/B: LAST MATCHING RULE WINS
-    // https://docs.renovatebot.com/configuration-options/#packagerules
-    "packageRules": [
-      // Workaround https://github.com/renovatebot/renovate/issues/16715
-      // our own way.  Rec. workaround in issue seems to disable more than
-      // only golang updates.
-      {
-        "matchDepTypes": ["golang"],  // used only for `go` property of `go.mod`
-        "enabled": false,
-      },
-
-      // Golang pseudo-version packages will spam with every Commit ID change.
-      // Limit update frequency.
-      {
-        "matchUpdateTypes": ["digest"],
-        "schedule": "after 1am and before 11am on the first day of the month",
-      },
-
-      // Workaround: rollbackPRs are not compatible with digest updates.
-      // This rule must appear AFTER the "digest" rule.
-      // Ref: https://github.com/renovatebot/renovate/discussions/18250
-      {
-        "matchLanguages": ["go"],  // No op
-
-        // Open rollback PR if updated dep. is removed (i.e. tag pulled
-        // due to major bug or security issue).
-        "rollbackPrs": true,
-      },
-    ],
   },
+
+  // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.
+  // https://docs.renovatebot.com/configuration-options/#packagerules
+  "packageRules": [
+    // Workaround https://github.com/renovatebot/renovate/issues/16715
+    {
+      "matchDepTypes": ["golang"],  // used only for `go` property of `go.mod`...
+      "matchManagers": ["gomod"],   // ...by the gomod manager
+      "enabled": false,
+    },
+
+    // Golang pseudo-version packages will spam with every Commit ID change.
+    // Limit update frequency.
+    {
+      "matchLanguages": ["go"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": "after 1am and before 11am on the first day of the month",
+    },
+
+    // Workaround: rollbackPRs are not compatible with digest updates.
+    // This is a catch-the-rest rule which must appear AFTER the go
+    // "digest" rule (above).
+    // Ref: https://github.com/renovatebot/renovate/discussions/18250
+    {
+      "matchLanguages": ["go"],
+      // Open rollback PR if updated dep. is removed (i.e. tag pulled
+      // due to major bug or security issue).
+      "rollbackPrs": true,
+    },
+  ],
 }


### PR DESCRIPTION
This was recommended by the upstream Renovate community: "Nesting packageRules under language objects can have unintended consequences".

Signed-off-by: Chris Evich <cevich@redhat.com>