### PR TITLE
Update bench_stuff schema

### DIFF
--- a/bench_stuff/.install.sh
+++ b/bench_stuff/.install.sh
@@ -37,7 +37,7 @@ virtualenv --clear --download \
 )
 install -v $INST_PERM_ARG -m '0644' -D -t "$INSTALL_PREFIX/lib/bs.venv/bin" \
     ./bench_stuff.py
-install -v $INST_PERM_ARG -D -t "$INSTALL_PREFIX/bin" ./cirrus-ci_artifacts
+install -v $INST_PERM_ARG -D -t "$INSTALL_PREFIX/bin" ./bench_stuff
 
 # Needed for installer testing
 echo "Successfully installed $INSTALL_NAME"

--- a/bench_stuff/README.md
+++ b/bench_stuff/README.md
@@ -1,8 +1,8 @@
 ### Performance metrics stuffer
 
 Python script which digests a `benchmarks.env` and `benchmarks.csv` file
-into a meaningful JSON document-set, then uploads it to google firebase.
+into a meaningful JSON document-set, then uploads it to google firestore.
 It's intended to be run from inside a container, in a podman CI environment.
 Besides the two benchmark related files, it requires the env. var.
 `$GOOGLE_APPLICATION_CREDENTIALS` is set to the path of a file containing
-JSON encoded credentials with access to firebase.
+JSON encoded credentials with access to firestore.

--- a/bench_stuff/bench_stuff.py
+++ b/bench_stuff/bench_stuff.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Digest `benchmarks.env` and `benchmarks.csv`, uploads to google firebase.
+Digest `benchmarks.env` and `benchmarks.csv`, uploads to google firestore.
 
 Expects to be called with $GOOGLE_APPLICATION_CREDENTIALS env. var. value
 pointing at a JSON service account key file, with access to write firestore
@@ -182,5 +182,5 @@ if __name__ == "__main__":
         v("Verbose-mode enabled")
     if args[1]:
         DRYRUN = True
-        v("Dry-run: Will not send data to firebase")
+        v("Dry-run: Will not send data to firestore")
     main(*args[1:])

--- a/bench_stuff/test/test_bench_stuff.py
+++ b/bench_stuff/test/test_bench_stuff.py
@@ -88,7 +88,7 @@ class TestMain(TestBase):
         test_client = self.FAKE_FIRESTORE.Client
 
         bench_call = call().collection('benchmarks')
-        type_call = call().collection().document(self.FAKE_INST)
+        type_call = call().collection().document(self.FAKE_UNAME_M)
         key_call = call().collection().document().collection().document(str(self.FAKE_TASK))
         calls = [bench_call, type_call, key_call]
         test_client.assert_has_calls(calls, any_order=True)


### PR DESCRIPTION
Move metadata values from a nested to the top-level document structure.
This makes both indexing and querying the data-point simpler.  Also add
an expiry meta-data field recording a date/time 30-days in the future.