### PR TITLE
Bench_stuff: Several minor fixups 

### DIFF
--- a/bench_stuff/bench_stuff.py
+++ b/bench_stuff/bench_stuff.py
@@ -121,7 +121,7 @@ def insert_data(bench_basis, meta_data, bench_data):
     doc_ref = db.collection('benchmarks').document(bench_basis['arch'])
     # Sub-collections must be anchored by a document, include all benchmark basis-details.
     batch.set(doc_ref, bench_basis, merge=True)  # Document likely to already exist
-    v(f"Reticulating {bench_basis['type']} document for task {meta_data['task']}")
+    v(f"Reticulating {bench_basis['arch']} document for task {meta_data['task']}")
     # Data points and metadata stored in a sub-collection of basis-document
     data_ref = doc_ref.collection('tasks').document(str(meta_data['task']))
     # Having meta-data at the top-level of the document makes indexing/querying simpler
@@ -150,16 +150,17 @@ def main(env_path, csv_path):
     v(f"Processing Basis: {pformat(bench_basis)}")
 
     meta_data = {
-        'ver': 2,  # identifies this schema version, increment for major layout changes.
-        'stamp': datetime.datetime.utcnow(),
+        'ver': 3,  # identifies this schema version, increment for major layout changes.
+        'occasion': datetime.datetime.utcnow(),
         # Firestore can delete old data automatically based on a field value.
-        'expires': datetime.datetime.utcnow() + datetime.timedelta(days=30),
+        'expires': datetime.datetime.utcnow() + datetime.timedelta(days=180),
         'build': env.int('CIRRUS_BUILD_ID'),
         'task': env.int('CIRRUS_TASK_ID'),  # collection-key
         # Will be pull/# for PRs; branch-name for branches
         'branch': env.str('CIRRUS_BRANCH'),
         'dist': env.str('DISTRO_NV'),
         'kern': env.str('UNAME_R'),
+        'commit': env.str('CIRRUS_CHANGE_IN_REPO')
     }
     bench_data = {}
 

--- a/bench_stuff/test/test_bench_stuff.py
+++ b/bench_stuff/test/test_bench_stuff.py
@@ -42,6 +42,7 @@ class TestBase(unittest.TestCase):
     FAKE_UNAME_R = "1.2.3-4.i386"
     FAKE_UNAME_M = "i386"
     FAKE_INST = "box"
+    FAKE_COMMIT = "1e06c1a47a71cc649032bf6ee71e14b990dae957"
 
     def setUp(self):
         bench_stuff.VERBOSE = False
@@ -59,7 +60,8 @@ class TestBase(unittest.TestCase):
             "DISTRO_NV": self.FAKE_DISTRO,
             "UNAME_R": self.FAKE_UNAME_R,
             "UNAME_M": self.FAKE_UNAME_M,
-            "INST_TYPE": self.FAKE_INST
+            "INST_TYPE": self.FAKE_INST,
+            "CIRRUS_CHANGE_IN_REPO": self.FAKE_COMMIT,
         }
         self.FAKE_DIE = Mock(side_effect=fakedie)
         patch('bench_stuff.firestore', new=self.FAKE_FIRESTORE).start()


### PR DESCRIPTION
* Fix a verbose message referencing an prior-implementation collection name (type).
* Rename the timestamp field to `occasion` since IMHO that's a more meaningful representation of it's identity.
* Increase the expiration time for new entries to 180 days since IMHO that better reflects their useful lifetime.
* Include the HEAD commit-ID with benchmark meta-data
* Bump the schema version to 3 due to field name changes.