### PR TITLE
Remove golang rollback PRs workaround

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -66,8 +66,8 @@ Validate this file before commiting with (from repository root):
     "postUpdateOptions": ["gomodTidy"],
 
     // In case a version in use is retracted, allow going backwards.
-    // N/B: This is NOT compatible with pseudo versions, see below.
-    "rollbackPrs": false,
+    // N/B: This does not apply to digest updates/pseudo versions.
+    "rollbackPrs": true,
 
     // Preserve (but continue to upgrade) any existing SemVer ranges.
     "rangeStrategy": "replace",
@@ -134,17 +134,6 @@ Validate this file before commiting with (from repository root):
   // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.
   // https://docs.renovatebot.com/configuration-options/#packagerules
   "packageRules": [
-    // Workaround: rollbackPRs are not compatible with digest updates.
-    // This is a catch-the-rest rule which must appear AFTER the go
-    // "digest" rule (above).
-    // Ref: https://github.com/renovatebot/renovate/discussions/18250
-    {
-      "matchLanguages": ["go"],
-      // Open rollback PR if updated dep. is removed (i.e. tag pulled
-      // due to major bug or security issue).
-      "rollbackPrs": true,
-    },
-
     // Github-action updates cannot consistently be tested in a PR.
     // This is caused by an unfixable architecture-flaw: Execution
     // context always depends on trigger, and we (obvious) can't know


### PR DESCRIPTION
The original discussion about this has been closed.  At the time, I believe I remember seeing a bugfix go through in the renovate change-logs.  In any case, it seems [rollback PRs are not working correctly](https://github.com/containers/podman/issues/18139#issuecomment-1517532310). Remove the workaround and enable rollbackPRs by default for golang.