### PR TITLE
Simplify renovate CI VM image updates

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -124,8 +124,8 @@ Validate this file before commiting with (from repository root):
       "matchStrings": ["c(?<currentValue>20\\d{6}t\\d{6}z-\\w+)"],
       "depNameTemplate": "containers/automation_images",
       "datasourceTemplate": "github-tags",
-      // N/B: Must match exactly to 'versioning' in the global 'regex' packageRules (below).
-      "versioningTemplate": "regex:^(?<minor>20\\d{6})t(?<patch>\\d{6})z-(?<major>\\w+)$",
+      "versioningTemplate": "loose",
+      "autoReplaceStringTemplate": "c{{{newVersion}}}",
     },
   ],
 
@@ -162,8 +162,6 @@ Validate this file before commiting with (from repository root):
       "matchManagers": ["regex"],
       "matchFiles": [".cirrus.yml"],  // full-path exact-match
       "groupName": "CI VM Image",
-      // N/B: Must match exactly to 'versioningTemplate' in the regexManagers (above).
-      "versioning": "regex:^(?<minor>20\\d{6})t(?<patch>\\d{6})z-(?<major>\\w+)$",
       // Somebody(s) need to stay on top of PRs as soon as they open.
       "assignees": ["cevich"],
       // Don't wait, roll out CI VM Updates immediately


### PR DESCRIPTION
There's no reason to capture major/minor/patch components (and they may be unhelpful/confusing/broken in some cases).  Simplify the setup to use "autoReplaceStringTemplate" to guide the replacement, and  "loose" versioning tell renovate to do a simple value sort on the github-tags.