### PR TITLE
Switch assignees to reviewers + fix broken urllib3 dep.

### DIFF
--- a/cirrus-ci_artifacts/requirements.txt
+++ b/cirrus-ci_artifacts/requirements.txt
@@ -15,4 +15,5 @@
 PyYAML~=6.0
 aiohttp[speedups]~=3.8
 gql[requests]~=3.3
-requests~=2.28
+requests>=2,<3
+urllib3<2.0.0

--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -162,8 +162,8 @@ Validate this file before commiting with (from repository root):
       "matchManagers": ["regex"],
       "matchFiles": [".cirrus.yml"],  // full-path exact-match
       "groupName": "CI VM Image",
-      // Somebody(s) need to stay on top of PRs as soon as they open.
-      "assignees": ["cevich"],
+      // Somebody(s) need to check image update PRs as soon as they open.
+      "reviewers": ["cevich"],
       // Don't wait, roll out CI VM Updates immediately
       "schedule": ["at any time"],
     },


### PR DESCRIPTION
For CI VM Image update PRs, add me as a reviewer instead of assignee. This is more appropriate to the action needed for these PRs.

Also fix urllib3 problem, ref: https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli