### PR TITLE
Enable gomod ind. deps for vulnerabilities.

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -50,6 +50,23 @@ Validate this file before commiting with (from repository root):
   // such that security-alert PRs may be opened immediately.
   "vulnerabilityAlerts": {
     "labels": ["dependencies", "security"],
+
+    // Force-enable renovate management of deps. which are otherwise
+    // disabled.  Note: Does not apply to any "ignorePaths" list, nor
+    // any deps. disabled via `packageRules` in this block
+    // (last-match wins rule).
+    "enabled": true,
+
+    // Indirect dependencies are disabled by default for the `gomod` manager.
+    // However, for vulnerability updates we may want them even if they break
+    // during renovate's automatic top-level `go mod tidy`.
+    "packageRules": [
+      {
+        "matchManagers": ["gomod"],
+        "matchDepTypes": ["indirect"],
+        "enabled": true,
+      }
+    ]
   },
 
   // On a busy repo, automatic-rebasing will swamp the CI system.


### PR DESCRIPTION
Indirect deps are disabled by default for the `gomod` manager. Ref:
https://docs.renovatebot.com/modules/manager/gomod/#post-update-options

Indirect deps are also broken for golang updates due to `go mod tidy` problems. Ref:
https://github.com/renovatebot/renovate/issues/ number 12999

However, for vulnerability related updates, perhaps we want a PR opened anyway.  Then at least a developer is able to fixup any `go mod tidy` related problems.