### PR TITLE
Minor: Fix flake8 finding

### DIFF
--- a/cirrus-ci_env/cirrus-ci_env.py
+++ b/cirrus-ci_env/cirrus-ci_env.py
@@ -120,7 +120,7 @@ class CirrusCfg:
                     if k == 'matrix':
                         err(f"Unsupported '{k}' key encountered in"
                             f" 'env' attribute of '{CirrusCfg._working}' task")
-                    raise(xcpt)
+                    raise xcpt
         return out
 
     def render_tasks(self, tasks: Mapping[str, Any]) -> Mapping[str, Any]:


### PR DESCRIPTION
Fix unit test failure: `./cirrus-ci_env.py:123:26: E275 missing whitespace after keyword`