### PR TITLE
Teach renovate how to manage golangci-lint versions

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -144,6 +144,16 @@ Validate this file before commiting with (from repository root):
       "versioningTemplate": "loose",
       "autoReplaceStringTemplate": "c{{{newVersion}}}",
     },
+    {
+      "fileMatch": ["^Makefile$"],
+      // make ignores whitespace around the value, make renovate do the same.
+      "matchStrings": ["^GOLANGCI_LINT_VERSION\\s+:=\\s+(?<currentValue>.+)\\s*$"],
+      "depNameTemplate": "golangci/golangci-lint",
+      "datasourceTemplate": "github-releases",
+      // Podman's installer script will puke if there's a 'v' prefix, as represented
+      // in upstream golangci/golangci-lint releases.
+      "extractVersionTemplate": "^v(?<version>.+)$",
+    }
   ],
 
   // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.


### PR DESCRIPTION
The podman and skopeo repos. both install this tool at runtime via a `Makefile` target.  Rather than duplicate update configurations in both repos., do it here.