### PR TITLE
Add passthrough_envars() function and test

### DIFF
--- a/common/lib/defaults.sh
+++ b/common/lib/defaults.sh
@@ -16,8 +16,3 @@ A_DEBUG=${A_DEBUG:-0}
 DEBUG_MSG_PREFIX="${DEBUG_MSG_PREFIX:-DEBUG:}"
 WARNING_MSG_PREFIX="${WARNING_MSG_PREFIX:-WARNING:}"
 ERROR_MSG_PREFIX="${ERROR_MSG_PREFIX:-ERROR:}"
-
-# When non-empty, should contain a regular expression that matches
-# any known or potential env. vars containing secrests or other
-# sensitive values.  For example `(.+PASSWORD.*)|(.+SECRET.*)|(.+TOKEN.*)`
-SECRET_ENV_RE=''

--- a/common/lib/platform.sh
+++ b/common/lib/platform.sh
@@ -16,3 +16,40 @@ if ((UID)) || ((_TEST_UID)); then
         fi
     fi
 fi
+# Regex defining all CI-related env. vars. necessary for all possible
+# testing operations on all platforms and versions.  This is necessary
+# to avoid needlessly passing through global/system values across
+# contexts, such as host->container or root->rootless user
+#
+# List of envariables which must be EXACT matches
+PASSTHROUGH_ENV_EXACT="${PASSTHROUGH_ENV_EXACT:-DEST_BRANCH|IMAGE_SUFFIX|DISTRO_NV|SCRIPT_BASE}"
+
+# List of envariable patterns which must match AT THE BEGINNING of the name.
+PASSTHROUGH_ENV_ATSTART="${PASSTHROUGH_ENV_ATSTART:-CI|TEST}"
+
+# List of envariable patterns which can match ANYWHERE in the name
+PASSTHROUGH_ENV_ANYWHERE="${PASSTHROUGH_ENV_ANYWHERE:-_NAME|_FQIN}"
+
+# List of expressions to exclude env. vars for security reasons
+SECRET_ENV_RE="${SECRET_ENV_RE:-(^PATH$)|(^BASH_FUNC)|(^_.*)|(.*PASSWORD.*)|(.*TOKEN.*)|(.*SECRET.*)}"
+
+# Return a list of environment variables that should be passed through
+# to lower levels (tests in containers, or via ssh to rootless).
+# We return the variable names only, not their values. It is up to our
+# caller to reference values.
+passthrough_envars() {
+    local passthrough_env_re="(^($PASSTHROUGH_ENV_EXACT)\$)|(^($PASSTHROUGH_ENV_ATSTART))|($PASSTHROUGH_ENV_ANYWHERE)"
+    local envar
+
+    for envar in SECRET_ENV_RE PASSTHROUGH_ENV_EXACT PASSTHROUGH_ENV_ATSTART PASSTHROUGH_ENV_ANYWHERE passthrough_env_re; do
+      if [[ -z "${!envar}" ]]; then
+        echo "Error: Required env. var. \$$envar is unset or empty in call to passthrough_envars()" > /dev/stderr
+        exit 1
+      fi
+    done
+
+    echo "Warning: Will pass env. vars. matching the following regex:
+$passthrough_env_re" > /dev/stderr
+
+    compgen -A variable | grep -Ev "$SECRET_ENV_RE" | grep -E  "$passthrough_env_re"
+}

--- a/common/test/testlib-platform.sh
+++ b/common/test/testlib-platform.sh
@@ -38,5 +38,38 @@ for OS_RELEASE_ID in 'debian' 'ubuntu'; do
   )
 done
 
+test_cmd "The passthrough_envars() func. has output by default." \
+  0 ".+" \
+  passthrough_envars
+
+(
+    # Confirm defaults may be overriden
+    PASSTHROUGH_ENV_EXACT="FOOBARBAZ"
+    PASSTHROUGH_ENV_ATSTART="FOO"
+    PASSTHROUGH_ENV_ANYWHERE="BAR"
+    export FOOBARBAZ="testing"
+
+    test_cmd "The passthrough_envars() func. w/ overriden expr. only prints name of test variable." \
+      0 "FOOBARBAZ" \
+      passthrough_envars
+)
+
+# Test from a mostly empty environment to limit possibility of expr mismatch flakes
+declare -a printed_envs
+printed_envs=(\
+  $(env --ignore-environment PATH="$PATH" FOOBARBAZ="testing" \
+         SECRET_ENV_RE="(^PATH$)|(^BASH_FUNC)|(^_.*)|(FOOBARBAZ)|(SECRET_ENV_RE)" \
+         CI="true" AUTOMATION_LIB_PATH="$AUTOMATION_LIB_PATH" \
+         bash -c "source $TEST_DIR/$SUBJ_FILENAME && passthrough_envars")
+)
+
+test_cmd "The passthrough_envars() func. w/ overriden \$SECRET_ENV_RE hides test variable." \
+    1 "0" \
+    expr match "${printed_envs[*]}" '.*FOOBARBAZ.*'
+
+test_cmd "The passthrough_envars() func. w/ overriden \$SECRET_ENV_RE returns CI variable." \
+    0 "[1-9]+[0-9]*" \
+    expr match "${printed_envs[*]}" '.*CI.*'
+
 # Must be last call
 exit_with_status

--- a/common/test/testlib.sh
+++ b/common/test/testlib.sh
@@ -88,7 +88,7 @@ test_cmd() {
         echo "# $@" > /dev/stderr
     fi
 
-    # Using egrep vs file safer than shell builtin test
+    # Using grep vs file safer than shell builtin test
     local a_out_f=$(mktemp -p '' "tmp_${FUNCNAME[0]}_XXXXXXXX")
     local a_exit=0
 
@@ -108,7 +108,7 @@ test_cmd() {
         if ((TEST_DEBUG)); then
             echo "Received $(wc -l $a_out_f | awk '{print $1}') output lines of $(wc -c $a_out_f | awk '{print $1}') bytes total"
         fi
-        if egrep -q "$e_out_re" "${a_out_f}.oneline"; then
+        if grep -Eq "$e_out_re" "${a_out_f}.oneline"; then
             _test_report "Command $1 exited as expected with expected output" "0" "$a_out_f"
         else
             _test_report "Expecting regex '$e_out_re' match to (whitespace-squashed) output" "1" "$a_out_f"


### PR DESCRIPTION
This function is otherwise duplicated in both buildah and podman CI, along with it's associated env. vars.  Provide it here to help limit duplication and cover it with testing.