### PR TITLE
Support $SUDO setup for debian environments

### DIFF
--- a/common/lib/platform.sh
+++ b/common/lib/platform.sh
@@ -2,16 +2,17 @@
 # Library of os/platform related definitions and functions
 # Not intended to be executed directly
 
-OS_RELEASE_VER="$(source /etc/os-release; echo $VERSION_ID | tr -d '.')"
-OS_RELEASE_ID="$(source /etc/os-release; echo $ID)"
-OS_REL_VER="$OS_RELEASE_ID-$OS_RELEASE_VER"
+OS_RELEASE_VER="${OS_RELEASE_VER:-$(source /etc/os-release; echo $VERSION_ID | tr -d '.')}"
+OS_RELEASE_ID="${OS_RELEASE_ID:-$(source /etc/os-release; echo $ID)}"
+OS_REL_VER="${OS_REL_VER:-$OS_RELEASE_ID-$OS_RELEASE_VER}"
 
-SUDO=""
-if [[ "$UID" -ne 0 ]]; then
-    SUDO="sudo"
-fi
-
-if [[ "$OS_RELEASE_ID" == "ubuntu" ]]; then
-    export DEBIAN_FRONTEND=noninteractive
-    SUDO="$SUDO env DEBIAN_FRONTEND=$DEBIAN_FRONTEND"
+# Ensure no user-input prompts in an automation context
+export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
+if ((UID)) || ((_TEST_UID)); then
+    SUDO="${SUDO:-sudo}"
+    if [[ "$OS_RELEASE_ID" =~ (ubuntu)|(debian) ]]; then
+        if [[ ! "$SUDO" =~ noninteractive ]]; then
+            SUDO="$SUDO env DEBIAN_FRONTEND=$DEBIAN_FRONTEND"
+        fi
+    fi
 fi

--- a/common/test/testlib-platform.sh
+++ b/common/test/testlib-platform.sh
@@ -23,5 +23,20 @@ for var in OS_RELEASE_VER OS_REL_VER; do
         test "$NODOT" == "${!var}"
 done
 
+for OS_RELEASE_ID in 'debian' 'ubuntu'; do
+  (
+    export _TEST_UID=$RANDOM  # Normally $UID is read-only
+    source "$TEST_DIR/$SUBJ_FILENAME" || exit 2
+
+    test_cmd "The '\$SUDO' env. var. is non-empty when \$_TEST_UID is non-zero" \
+        0 "" \
+        test -n "$SUDO"
+
+    test_cmd "The '\$SUDO' env. var. contains 'noninteractive' when '\$_TEST_UID' is non-zero" \
+        0 "noninteractive" \
+        echo "$SUDO"
+  )
+done
+
 # Must be last call
 exit_with_status


### PR DESCRIPTION
This is esp. used during CI VM image builds where only a user account is available for some stages.  It's important to block `sudo apt-get` calls from asking for user input during update/install.