### PR TITLE
Improve build-push error handling

### DIFF
--- a/build-push/test/fake_buildah.sh
+++ b/build-push/test/fake_buildah.sh
@@ -29,13 +29,15 @@ if [[ "$1" == "build" ]]; then
 elif [[ "$1" == "manifest" ]]; then
     # validate json while outputing it
     jq . $DATF
-elif [[ "$1" =~ info ]]; then
+elif [[ "$1" == "info" ]]; then
     case "$@" in
         *arch*) echo "amd64" ;;
         *cpus*) echo "2" ;;
         *) exit 1 ;;
     esac
+elif [[ "$1" == "images" ]]; then
+    echo '[{"names":["localhost/foo/bar:latest"]}]'
 else
-    echo "ERROR: Unexpected call to fake_buildah.sh"
+    echo "ERROR: Unexpected arg '$1' to fake_buildah.sh" > /dev/stderr
     exit 9
 fi


### PR DESCRIPTION
Around the time of this commit, [the automated multiarch manifest-list builds for both skopeo and podman have been failing](https://cirrus-ci.com/task/5905066138271744?logs=main#L985) somewhere in the `build-push.sh` script.  The actual build appears to work fine, the `tag-version.sh` mod-command runs fine, but the tag-search in `get_manifest_tags()` (called by `push_images()`) fails with the error:

`jq: error (at <stdin>:29): Cannot iterate over null (null)`

Unfortunately the problem does not reproduce for me locally, nor can it be reproduced using a dry-run build (`--nopush` bypasses the tag search.) Improve debugging of this situation by moving the `if ((PUSH))` check and adding an exception clause to display the would-be pushed images (and tags).

Also:

* Simplify the `get_manifest_tags()` tag search by adjusting the jq filter to gracefully ignore an empty set of images and/or images without any list of names.  Rely on `push_images()` catching the empty-list and throwing an error.
* Add a comment regarding the need for the `confirm_arches` call after the `parallel_build` call in the main part of the script.
* Improve the debug-ability of `confirm_arches()` in the case of a bad/incomplete/unreadable manifest-list (see item above). Detect both inspect command errors and jq/pipeline errors.  In the case of jq/pipeline failure, show the input JSON to aid debugging.