### PR TITLE
renovate: add CI-colon-DOCS prefix for golangci-lint updates

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -198,5 +198,11 @@ Validate this file before commiting with (from repository root):
       // Don't wait, roll out CI VM Updates immediately
       "schedule": ["at any time"],
     },
+
+    // Add CI:DOCS prefix to skip unnecessary tests for golangci updates in podman CI.
+    {
+      "matchPackageNames": ["golangci/golangci-lint"],
+      "commitMessagePrefix": "[CI:DOCS]",
+    },
   ],
 }


### PR DESCRIPTION
In podman CI golangci-lint is only run in the validate step so there is no point in running the full test suite for such updates. The validate task is included with CI:DOCS so that should be good enough even if it is technically not a doc change.