### PR TITLE
Minor: Breadcrumb version and UTC timestamp

### DIFF
--- a/bin/install_automation.sh
+++ b/bin/install_automation.sh
@@ -125,8 +125,8 @@ install_automation() {
 
     dbg "Configuring environment file $INSTALLATION_SOURCE/environment"
     cat <<EOF>"$INSTALLATION_SOURCE/environment"
-# Added on $(date --iso-8601=minutes) by $actual_inst_path/bin/$SCRIPT_FILENAME"
-# Any manual modifications will be lost upon upgrade or reinstall.
+# Added on $(date --utc --iso-8601=minutes) by $actual_inst_path/bin/$SCRIPT_FILENAME"
+# for version '$AUTOMATION_VERSION'.  Any manual modifications will be lost upon upgrade or reinstall.
 export AUTOMATION_LIB_PATH="$actual_inst_path/lib"
 export PATH="$PATH:$actual_inst_path/bin"
 EOF


### PR DESCRIPTION
Otherwise the timestamp is localized, which may be harder for humans
to relate/translate WRT other time-based items.  For example, Cirrus-CI
and GHA cron specifications.  Also add mention of the just-installed
version to the env. file, also to help with any needed auditing.