### PR TITLE
Cirrus-CI persistent worker pool management

### DIFF
--- a/mac_pw_pool/.gitignore
+++ b/mac_pw_pool/.gitignore
@@ -1,0 +1,1 @@
+/pw_status.txt*

--- a/mac_pw_pool/InstanceSSH.sh
+++ b/mac_pw_pool/InstanceSSH.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Helper for humans to access an existing instance.  It depends on:
+#
+# * You know the instance-id value.
+# * All requirements listed in the top `LaunchInstances.sh` comment.
+# * The local ssh-agent is able to supply the appropriate private key.
+
+# shellcheck source-path=SCRIPTDIR
+source $(dirname ${BASH_SOURCE[0]})/pw_lib.sh
+
+SSH="ssh $SSH_ARGS"  # N/B: library default nulls stdin
+
+[[ -n "$1" ]] || \
+    die "Must provide EC2 instance ID as first argument"
+instance_id="${1:-EmptyID}"
+shift
+
+inst_json=$($AWS ec2 describe-instances --instance-ids "$instance_id")
+pub_dns=$(jq -r -e '.Reservations?[0]?.Instances?[0]?.PublicDnsName?' <<<"$inst_json")
+if [[ -z "$pub_dns" ]] || [[ "$pub_dns" == "null" ]]; then
+    die "Instance '$1' does not exist, or have a public DNS address allocated (yet)."
+fi
+
+$SSH ec2-user@$pub_dns "$@"

--- a/mac_pw_pool/LaunchInstances.sh
+++ b/mac_pw_pool/LaunchInstances.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Script intended to be executed by humans (and eventually automation) to
+# ensure instances are launched from the current template version, on all
+# available Cirrus-CI Persistent Worker M1 Mac dedicated hosts.  These
+# dedicated host (slots) are selected at runtime based their possessing any
+# value for the tag `PWPoolReady`.  The script assumes:
+#
+# * The `aws` CLI tool is installed on $PATH.
+# * Appropriate `~/.aws/credentials` credentials are setup.
+# * The us-east-1 region is selected in `~/.aws/config`.
+#
+# N/B: Dedicated Host names and instance names are assumed to be identical,
+# only the IDs differ.
+
+# shellcheck source-path=SCRIPTDIR
+source $(dirname ${BASH_SOURCE[0]})/pw_lib.sh
+
+L_DEBUG="${L_DEBUG:0}"
+if ((L_DEBUG)); then
+    X_DEBUG=1
+    warn "Debugging enabled - temp. dir will not be cleaned up '$TEMPDIR' $(ctx 0)."
+    trap EXIT
+fi
+
+# Helper intended for use inside `name_hostid` loop.
+# arg1 either "INST" or "HOST"
+# arg2: Brief failure message
+# arg3: Failure message details
+handle_failure() {
+    [[ -n "$inststate" ]] || die "Expecting \$inststate to be set $(ctx 2)"
+    [[ -n "$name" ]] || die "Expecting \$name to be set $(ctx 2)"
+    if [[ "$1" != "INST" ]] && [[ "$1" != "HOST" ]]; then
+        die "Expecting either INST or HOST as argument $(ctx 2)"
+    fi
+    [[ -n "$2" ]] || die "Expecting brief failure message $(ctx 2)"
+    [[ -n "$3" ]] || die "Expecting detailed failure message $(ctx 2)"
+
+    warn "$2 $(ctx 2)"
+    (
+        # Script is sensitive to this first-line format
+        echo "# $name $1 ERROR: $2"
+        # Make it obvious which host/instance the details pertain to
+        awk -e '{print "#    "$0}'<<<"$3"
+    ) > "$inststate"
+}
+
+# Wrapper around handle_failure()
+host_failure() {
+    [[ -r "$hostoutput" ]] || die "Expecting readable $hostoutput file $(ctx)"
+    handle_failure HOST "$1" "aws CLI output: $(<$hostoutput)"
+}
+
+inst_failure() {
+    [[ -r "$instoutput" ]] || die "Expecting readable $instoutput file $(ctx)"
+    handle_failure INST "$1" "aws CLI output: $(<$instoutput)"
+}
+
+# Find dedicated hosts to operate on.
+dh_flt="Name=tag-key,Values=PWPoolReady"
+dh_qry='Hosts[].{HostID:HostId, Name:[Tags[?Key==`Name`].Value][] | [0]}'
+dh_searchout="$TEMPDIR/hosts.output"  # JSON or error message
+if ! $AWS ec2 describe-hosts --filter "$dh_flt" --query "$dh_qry" &> "$dh_searchout"; then
+    die "Searching for dedicated hosts $(ctx 0):
+$(<$dh_searchout)"
+fi
+
+# Array item format: "<Name> <ID>"
+dh_fmt='.[] | .Name +" "+ .HostID'
+# Avoid always processing hosts in the same alpha-sorted order, as that would
+# mean hosts at the end of the list consistently get the least management.
+if ! readarray NAME2HOSTID <<<$(json_query "$dh_fmt" "$dh_searchout" | sort --random-sort); then
+    die "Extracting dedicated host 'Name' and 'HostID' fields $(ctx 0):
+$(<$dh_searchout)"
+fi
+
+n_dh=0
+n_dh_total=${#NAME2HOSTID[@]}
+if ! ((n_dh_total)); then
+    msg "No dedicated hosts found"
+    exit 0
+fi
+
+# At maximum possible creation-speed, there's aprox. 3-hours of time between
+# an instance going down, until another can be up and running again.  Since
+# instances are all on shutdown + self-termination timers, it would hurt
+# pool availability if multiple instances all went down at the same time.
+# Therefore, instance creations must be staggered by according to this
+# window.
+CREATE_STAGGER_HOURS=3
+latest_launched="1970-01-01T00:00+00:00"  # in case $PWSTATE is missing
+dcmpfmt="+%Y%m%d%H%M"  # date comparison format compatible with numeric 'test'
+if [[ -r "$PWSTATE" ]]; then
+    # N/B: Asumes data in $PWSTATE represents reality.  It may not,
+    # for example if instances have been manually created or terminated.
+    # Querying the actual state would make this script much more complex.
+    declare -a _pwstate
+    readarray -t _pwstate <<<$(grep -E -v '^($|#+| +)' "$PWSTATE")
+    for _pwentry in "${_pwstate[@]}"; do
+        read -r name instance_id launch_time<<<"$_pwentry"
+        launched_hour=$(date -u -d "$launch_time" "$dcmpfmt")
+        latest_launched_hour=$(date -u -d "$latest_launched" "$dcmpfmt")
+        dbg "instance $name launched on $launched_hour, latest launched hour: $latest_launched_hour"
+        if [[ $launched_hour -gt $latest_launched_hour ]]; then
+            latest_launched="$launch_time"
+        fi
+    done
+fi
+dbg "latest_launched=$latest_launched (according to \$PWSTATE)"
+
+msg "Operating on $n_dh_total dedicated hosts at $(date -u -Iminutes):"
+echo -e "# $(basename ${BASH_SOURCE[0]}) run $(date -u -Iseconds)\n#" > "$TEMPDIR/$(basename $PWSTATE)"
+for name_hostid in "${NAME2HOSTID[@]}"; do
+    n_dh=$(($n_dh+1))
+    _I="    "
+    msg " "  # make output easier to read
+
+    read -r name hostid<<<"$name_hostid"
+    msg "Working on Dedicated Host #$n_dh/$n_dh_total '$name' for HostID '$hostid'."
+
+    hostoutput="$TEMPDIR/${name}_host.output" # JSON or error message from aws describe-hosts
+    instoutput="$TEMPDIR/${name}_inst.output" # JSON or error message from aws describe-instance or run-instance
+    inststate="$TEMPDIR/${name}_inst.state"  # Line to append to $PWSTATE
+
+    if ! $AWS ec2 describe-hosts --filter "Name=tag:Name,Values=$name" &> "$hostoutput"; then
+        host_failure "Failed to look up dedicated host."
+        continue
+    # Allow hosts to be taken out of service easily/manually by editing its tags.
+    # Also detect any JSON parsing problems in the output.
+    elif ! PWPoolReady=$(json_query '.Hosts?[0]?.Tags? | map(select(.Key == "PWPoolReady")) | .[].Value' "$hostoutput"); then
+        host_failure "Empty/null/failed JSON query of PWPoolReady tag."
+        continue
+    elif [[ "$PWPoolReady" != "true" ]]; then
+        msg "Dedicated host tag 'PWPoolReady' == '$PWPoolReady' != 'true'."
+        echo "# $name HOST DISABLED: PWPoolReady==$PWPoolReady" > "$inststate"
+        continue
+    fi
+
+    if ! hoststate=$(json_query '.Hosts?[0]?.State?' "$hostoutput"); then
+        host_failure "Empty/null/failed JSON query of dedicated host state."
+        continue
+    fi
+
+    if [[ "$hoststate" == "pending" ]] || [[ "$hoststate" == "under-assessment" ]]; then
+        # When an instance is terminated, its dedicated host goes into an unusable state
+        # for about 1-1/2 hours.  There's absolutely nothing that can be done to avoid
+        # this or work around it.  Ignore hosts in this state, assuming a later run of the
+        # script will start an instance on the (hopefully) available host).
+        #
+        # I have no idea what 'under-assessment'  means, and it doesn't last as long as 'pending',
+        # but functionally it behaves the same.
+        msg "Dedicated host is untouchable due to '$hoststate' state."
+        # Reference the actual output text, in case of false-match or unexpected contents.
+        echo "# $name HOST BUSY: $hoststate" > "$inststate"
+        continue
+    elif [[ "$hoststate" != "available" ]]; then
+        # The "available" state means the host is ready for zero or more instances to be created.
+        # Detect all other states (they should be extremely rare).
+        host_failure "Unsupported dedicated host state '$hoststate'."
+        continue
+    fi
+
+    # Counter-intuitively, dedicated hosts can support more than one running instance.  Except
+    # for Mac instances, but this is not reflected anywhere in the JSON.  Trying to start a new
+    # Mac instance on an already occupied host is bound to fail.  Inconveniently this error
+    # will look an aweful lot like many other types of errors, confusing any human examining
+    # $PWSTATE.  Detect dedicated-hosts with existing instances.
+    InstanceId=$(set +e; jq -r '.Hosts?[0]?.Instances?[0].InstanceId?' "$hostoutput")
+    dbg "InstanceId='$InstanceId'"
+
+    # Stagger creation of instances by $CREATE_STAGGER_HOURS
+    launch_new=0
+    if [[ "$InstanceId" == "null" ]] || [[ "$InstanceId" == "" ]]; then
+      launch_threshold=$(date -u -Iminutes -d "$latest_launched + $CREATE_STAGGER_HOURS hours")
+      launch_threshold_hour=$(date -u -d "$launch_threshold" "$dcmpfmt")
+      now_hour=$(date -u "$dcmpfmt")
+      dbg "launch_threshold_hour=$launch_threshold_hour"
+      dbg "             now_hour=$now_hour"
+      if [[ $now_hour -lt $launch_threshold_hour ]]; then
+          msg "Cannot launch new instance until $launch_threshold"
+          echo "# $name HOST BUSY: Inst. creation delayed until $launch_threshold" > "$inststate"
+          continue
+      else
+          launch_new=1
+      fi
+    fi
+
+    if ((launch_new)); then
+        msg "Creating new instance on host."
+        if ! $AWS ec2 run-instances \
+                  --launch-template LaunchTemplateName=CirrusMacM1PWinstance \
+                  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$name}]" \
+                  --placement "HostId=$hostid" &> "$instoutput"; then
+            inst_failure "Failed to create new instance on available host."
+            continue
+        else
+            # Block further launches (assumes script is running in a 10m while loop).
+            latest_launched=$(date -u -Iminutes)
+            msg "Successfully created new instance; Waiting for 'running' state (~1m typical)..."
+            # N/B: New Mac instances take ~5-10m to actually become ssh-able
+            if ! InstanceId=$(json_query '.Instances?[0]?.InstanceId' "$instoutput"); then
+                inst_failure "Empty/null/failed JSON query of brand-new InstanceId"
+                continue
+            fi
+            # Instance "running" status is good enough for this script, and since network
+            # accessibility can take 5-20m post creation.
+            # Polls 40 times with 15-second delay (non-configurable).
+            if ! $AWS ec2 wait instance-running \
+                    --instance-ids $InstanceId &> "${instoutput}.wait"; then
+                # inst_failure() would include unhelpful $instoutput detail
+                (
+                    echo "# $name INST ERROR: Running-state timeout."
+                    awk -e '{print "#    "$0}' "${instoutput}.wait"
+                ) > "$inststate"
+                continue
+            fi
+        fi
+    fi
+
+    # If an instance was created, $instoutput contents are already obsolete.
+    # If an existing instance, $instoutput doesn't exist.
+    if ! $AWS ec2 describe-instances --instance-ids $InstanceId &> "$instoutput"; then
+        inst_failure "Failed to describe host instance."
+        continue
+    fi
+
+    # Describe-instance has unnecessarily complex structure, simplify it.
+    if ! json_query '.Reservations?[0]?.Instances?[0]?' "$instoutput" > "${instoutput}.simple"; then
+        inst_failure "Empty/null/failed JSON simplification of describe-instances."
+    fi
+    mv "$instoutput" "${instoutput}.describe"  # leave for debugging
+    mv "${instoutput}.simple" "${instoutput}"
+
+    msg "Parsing new or existing instance ($InstanceId) details."
+    if ! InstanceId=$(json_query '.InstanceId' $instoutput); then
+        inst_failure "Empty/null/failed JSON query of InstanceId"
+        continue
+    elif ! LaunchTime=$(json_query '.LaunchTime' $instoutput); then
+        inst_failure "Empty/null/failed JSON query of LaunchTime"
+        continue
+    fi
+
+    echo "$name $InstanceId $LaunchTime" > "$inststate"
+done
+
+_I=""
+msg " "
+msg "Processing all dedicated host and instance states."
+new_error=0
+for name_hostid in "${NAME2HOSTID[@]}"; do
+    read -r name hostid<<<"$name_hostid"
+    inststate="$TEMPDIR/${name}_inst.state"
+    [[ -r "$inststate" ]] || die "Expecting to find instance-state file $inststate for host '$name' $(ctx 0)."
+    if grep -E -q '^# .+ .+ ERROR: ' $inststate; then
+        new_error=1
+    fi
+    cat "$inststate" >> "$TEMPDIR/$(basename $PWSTATE)"
+done
+
+dbg "Creating/updating state file"
+if [[ -r "$PWSTATE" ]]; then
+    cp "$PWSTATE" "${PWSTATE}~"
+fi
+mv "$TEMPDIR/$(basename $PWSTATE)" "$PWSTATE"
+
+dbg "Handling any errors"
+if ((new_error)); then
+    die "Processing one or more hosts or instances $(ctx 0):
+$(<$PWSTATE)"
+fi

--- a/mac_pw_pool/README.md
+++ b/mac_pw_pool/README.md
@@ -1,0 +1,82 @@
+# Cirrus-CI persistent worker maintenance
+
+These docs and scripts were implemented in a hurry.  They both likely
+contain cringe-worthy content and incomplete information.
+This might be improved in the future.  Sorry.
+
+## Prerequisites
+
+* The `aws` binary present somewhere on `$PATH`.
+* Standard AWS `credentials` and `config` files exist under `~/.aws`
+  and set the region to `us-east-1`.
+* A copy of the ssh-key referenced by `CirrusMacM1PWinstance` launch template
+  under "Assumptions" below.
+* The ssh-key has been added to a running ssh-agent.
+* The env. var. `POOLTOKEN` is set to the Cirrus-CI persistent worker pool
+  token value.
+
+## Assumptions
+
+* You've read all scripts in this directory and meet any requirements
+  stated within.
+* You have permissions to access all referenced AWS resources.
+* There are one or more dedicated hosts allocated and have set:
+  * A name tag like `MacM1-<some number>`
+  * The `mac2` instance family
+  * The `mac2.metal` instance type
+  * Disabled "Instance auto-placement", "Host recovery", and "Host maintenance"
+  * Quantity: 1
+  * Tags: `automation=false` and `PWPoolReady=true`
+* The EC2 `CirrusMacM1PWinstance` instance-template exists and sets:
+  * Shutdown-behavior: terminate
+  * Same "key pair" referenced under `Prerequisites`
+  * All other required instance parameters complete
+  * A user-data script that shuts down the instance after 2 days.
+
+## Operation (Theory)
+
+The goal is to maintain sufficient alive/running/working instances
+to service most Cirrus-CI tasks pointing at the pool.  This is
+best achieved with slower maintenance of hosts compared to setup
+of ready instances.  This is because hosts can be inaccessible for
+1-1/2 hours, but instances come up in ~10-20m, ready for setup.
+
+Both hosts and instances may be taken out of all management loops
+by setting or removing its `PWPoolReady=true` tag.  Otherwise,
+with a fully populated set of dedicated hosts and running instances,
+state should be maintained using two loops:
+
+1. `while ./LaunchInstances.sh; do echo "Sleeping..."; sleep 10m; done`
+2. `while ./SetupInstances.sh; do echo "Sleeping..."; sleep 2m; done`
+
+Cirrus-CI will assign tasks (specially) targeted at the pool, to an
+instance with a running listener.  If there are none, the task will
+queue forever (there might be a 24-hour timeout, I can't remember).
+From a PR perspective, there is zero control over which instance you
+get.  It could easily be one somebody's previous task barfed all over
+and ruined.
+
+## Security
+
+To thwart attempts to hijack or use instances for nefarious purposes,
+each employs three separate self-termination mechanisms.  Two of them
+depend on the instance's shutdown behavior being set to `terminate`
+(see above).  These mechanisms also ensure the workers remain relatively
+"clean" an "fresh" from a "CI-Working" perspective.
+
+Note: Should there be an in-flight CI task on a worker at
+shutdown, Cirrus-CI will perform a single automatic re-run on an
+available worker.
+
+1. Daily, a Cirrus-cron job runs and kills any instance running longer
+   than 3 days.
+2. Each instance's startup script runs a background 2-day sleep and
+   shutdown command (via MacOS-init consuming instance user-data).
+3. A setup script run on each instance starts a pool-listener
+   process.
+   1. If the worker process dies the instance shuts down.
+   2. After 24 +/-4 hours the instance shuts down if there are no
+      cirrus-agent processes (presumably servicing a CI task).
+   3. After 2 more hours, the instance shuts down regardless of any
+      running agents - probably hung/stuck agent process or somebody's
+      started a fake agent doing "bad things".

--- a/mac_pw_pool/SetupInstances.sh
+++ b/mac_pw_pool/SetupInstances.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Script intended to be executed by humans (and eventually automation)
+# to provision any/all accessible Cirrus-CI Persistent Worker instances
+# as they become available.  This is intended to operate independently
+# from `LaunchInstances.sh` soas to "hide" the nearly 2-hours of cumulative
+# startup and termination wait time.  This script depends on:
+#
+# * The $PWSTATE file created/updated by `LaunchInstances.sh`.
+# * All requirements listed in the top `LaunchInstances.sh` comment.
+# * The local ssh-agent is able to supply the appropriate private key.
+# * The $POOLTOKEN env. var. is defined
+
+# shellcheck source-path=SCRIPTDIR
+source $(dirname ${BASH_SOURCE[0]})/pw_lib.sh
+
+# Set non-zero to enable debugging / prevent removal of temp. dir.
+S_DEBUG="${S_DEBUG:0}"
+if ((S_DEBUG)); then
+    X_DEBUG=1
+    warn "Debugging enabled - temp. dir will not be cleaned up '$TEMPDIR' $(ctx 0)."
+    trap EXIT
+fi
+
+[[ -n "$POOLTOKEN" ]] || \
+    die "Expecting \$POOLTOKEN to be defined/non-empty $(ctx 0)."
+
+[[ -r "$PWSTATE" ]] || \
+    die "Can't read from state file: $PWSTATE"
+
+declare -a _pwstate
+readarray -t _pwstate <<<$(grep -E -v '^($|#+| +)' "$PWSTATE")
+n_inst=0
+n_inst_total="${#_pwstate[@]}"
+if [[ $n_inst_total -eq 0 ]]; then
+    msg "No operable hosts found in $PWSTATE:
+$(<$PWSTATE)"
+    # Assume this script is running in a loop, and unf. there are
+    # simply no dedicated-hosts in 'available' state.
+    exit 0
+fi
+
+# N/B: Assumes $PWSTATE represents reality
+msg "Operating on $n_inst_total instances from $(head -1 $PWSTATE)"
+# Indent for messages inside loop
+for _pwentry in "${_pwstate[@]}"; do
+    read -r name instance_id launch_time<<<"$_pwentry"
+    _I="    "
+    msg " "
+    n_inst=$(($n_inst+1))
+    msg "Working on Instance #$n_inst/$n_inst_total '$name' with ID '$instance_id'."
+
+    instoutput="$TEMPDIR/${name}_inst.output"
+    ncoutput="$TEMPDIR/${name}_nc.output"
+    logoutput="$TEMPDIR/${name}_ssh.output"
+
+    if ! $AWS ec2 describe-instances --instance-ids $instance_id &> "$instoutput"; then
+        warn "Could not query instance $instance_id $(ctx 0)."
+        continue
+    fi
+
+    # Check if instance should be managed
+    if ! PWPoolReady=$(json_query '.Reservations?[0]?.Instances?[0]?.Tags? | map(select(.Key == "PWPoolReady")) | .[].Value' "$instoutput"); then
+        warn "Instance does not have a PWPoolReady tag"
+        PWPoolReady="tag absent"
+    fi
+
+    if [[ "$PWPoolReady" != "true" ]]; then
+        msg "Instance disabled via tag 'PWPoolReady' == '$PWPoolReady' != 'true'."
+        continue
+    fi
+
+    msg "Verifying lifetime <3 days (launched '$launch_time')"
+    # It's really important that instances have a defined and risk-relative
+    # short lifespan.  Multiple mechanisms are in place to assist, but none
+    # are perfect.  Warn operators if any instance has been alive "too long".
+    now=$(date -u +%Y%m%d)
+    then=$(date -u -d "$launch_time" +%Y%m%d)
+    # c/automation_images Cirrus-CI job terminates EC2 instances after 3 days
+    # TODO: Consider simply terminating instance here instead of hard-failing script.
+    [[ $((now-then)) -le 3 ]] || \
+        die "Instance found alive longer than it should be, please investigate $(ctx 0)"
+
+    msg "Looking up public DNS"
+    if ! pub_dns=$(json_query '.Reservations?[0]?.Instances?[0]?.PublicDnsName?' "$instoutput"); then
+        warn "Could not lookup of public DNS for instance $instance_id $(ctx 0)"
+        continue
+    fi
+
+    msg "Attempting to contact '$name' at $pub_dns"
+    if ! nc -z -w 13 $pub_dns 22 &> "$ncoutput"; then
+        warn "Could not connect to port 22 on '$pub_dns' $(ctx 0)."
+        continue
+    fi
+
+    if ! $SSH ec2-user@$pub_dns true; then
+        warn "Could not ssh to 'ec2-user@$pub_dns' $(ctx 0)."
+        continue
+    fi
+
+    msg "Checking state of instance"
+    if ! $SSH ec2-user@$pub_dns test -r .setup.done; then
+
+        if ! $SSH ec2-user@$pub_dns test -r .setup.started; then
+            if $SSH ec2-user@$pub_dns test -r setup.log; then
+                warn "Setup log found, prior executions may have failed $(ctx 0)."
+            fi
+
+            msg "Setting up new instance"
+
+            # Switch to bash for consistency && some ssh commands below
+            # don't play nicely with zsh.
+            $SSH ec2-user@$pub_dns sudo chsh -s /bin/bash ec2-user &> /dev/null
+
+            if ! $SCP $SETUP_SCRIPT $SPOOL_SCRIPT ec2-user@$pub_dns:/var/tmp/; then
+                warn "Could not scp scripts to instance $(ctx 0)."
+                continue
+            fi
+
+            if ! $SCP $CIENV_SCRIPT ec2-user@$pub_dns:./; then
+                warn "Could not scp CI Env. script to instance $(ctx 0)."
+                continue
+            fi
+
+            if ! $SSH ec2-user@$pub_dns chmod +x /var/tmp/*.sh; then
+                warn "Could not chmod scripts $(ctx 0)."
+                continue
+            fi
+
+            # Run setup script in background b/c it takes ~5-10m to complete.
+            $SSH ec2-user@$pub_dns \
+                env POOLTOKEN=$POOLTOKEN \
+                bash -c '/var/tmp/setup.sh &> setup.log & disown %-1'
+
+            msg "Setup script started"
+            # Let it run in the background
+            continue
+        fi
+
+        since=$($SSH ec2-user@$pub_dns tail -1 .setup.started)
+        msg "Setup not complete;  Now: $(date -u -Iseconds)"
+        msg "Setup running since:      $since"
+        continue
+    fi
+
+    msg "Instance setup has completed"
+
+    if ! $SSH ec2-user@$pub_dns pgrep -u "${name}-worker" -f -q "cirrus worker run"; then
+        warn "Cirrus worker listener process is not running $(ctx 0)."
+        continue
+    fi
+
+    msg "Cirrus worker listener process is running"
+
+    logpath="/private/tmp/${name}-worker.log"  # set in setup.sh
+    # The log output from "cirrus worker run" only records task starts
+    if ! $SSH ec2-user@$pub_dns "cat $logpath" &> "$logoutput"; then
+        warn "Missing worker log $logpath"
+    else
+        dbg "worker log:
+$(<$logoutput)"
+    fi
+
+    # First line of log should always match this
+    if ! grep -q 'worker successfully registered' "$logoutput"; then
+        warn "Expecting successful registration log entry:
+$(head -1 "$logoutput")"
+        continue
+    fi
+
+    msg "Cirrus worker listener successfully registered at least once"
+
+    if grep -Eq 'level=error.+msg.+failed' "$logoutput"; then
+        warn "Failure messages present in worker log"
+    fi
+
+    # The CI user has write-access to this log file on the instance,
+    # make this known to humans in case they care.
+    n_tasks=$(grep -Ei 'started' "$logoutput" | wc -l) || true
+    msg "Apparent worker task executions: $n_tasks"
+done

--- a/mac_pw_pool/ci_env.sh
+++ b/mac_pw_pool/ci_env.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script drops the caller into a bash shell inside an environment
+# substantially similar to a Cirrus-CI task running on this host.
+# The envars below may require adjustment to better fit them to
+# current/ongoing development in podman's .cirrus.yml
+
+set -eo pipefail
+
+# Not running as the pool worker user
+if [[ "$USER" == "ec2-user" ]]; then
+    PWINST=$(curl -sSLf http://instance-data/latest/meta-data/tags/instance/Name)
+    PWUSER=$PWINST-worker
+
+    if [[ ! -d "/Users/$PWUSER" ]]; then
+        echo "Warnin: Instance hasn't been setup.  Assuming caller will tend to this."
+        sudo sysadminctl -addUser $PWUSER
+    fi
+
+    sudo install -o $PWUSER "${BASH_SOURCE[0]}" "/Users/$PWUSER/"
+    exec sudo su -c "/Users/$PWUSER/$(basename ${BASH_SOURCE[0]})" - $PWUSER
+fi
+
+# Export all CI-critical envars defined below
+set -a
+
+CIRRUS_SHELL="/bin/bash"
+CIRRUS_TASK_ID="0123456789"
+CIRRUS_WORKING_DIR="$HOME/ci/task-${CIRRUS_TASK_ID}"
+
+GOPATH="$CIRRUS_WORKING_DIR/.go"
+GOCACHE="$CIRRUS_WORKING_DIR/.go/cache"
+GOENV="$CIRRUS_WORKING_DIR/.go/support"
+
+CONTAINERS_MACHINE_PROVIDER="applehv"
+
+MACHINE_IMAGE="https://fedorapeople.org/groups/podman/testing/applehv/arm64/fedora-coreos-38.20230925.dev.0-applehv.aarch64.raw.gz"
+
+GINKGO_TAGS="remote exclude_graphdriver_btrfs btrfs_noversion exclude_graphdriver_devicemapper containers_image_openpgp remote"
+
+DEBUG_MACHINE="1"
+
+ORIGINAL_HOME="$HOME"
+HOME="$HOME/ci"
+TMPDIR="/private/tmp/ci"
+mkdir -p "$TMPDIR" "$CIRRUS_WORKING_DIR"
+
+# Drop caller into the CI-like environment
+cd "$CIRRUS_WORKING_DIR"
+bash -il

--- a/mac_pw_pool/pw_lib.sh
+++ b/mac_pw_pool/pw_lib.sh
@@ -1,0 +1,87 @@
+
+# This library is intended to be sourced by other scripts inside this
+# directory.  All other usage contexts may lead to unintended outcomes.
+# only the IDs differ.  Assumes the sourcing script defines a `dbg()`
+# function.
+
+SCRIPT_FILENAME=$(basename "$0")  # N/B: Caller's arg0, not this library file path.
+SCRIPT_DIRPATH=$(dirname "$0")
+LIB_DIRPATH=$(dirname "${BASH_SOURCE[0]}")
+TEMPDIR=$(mktemp -d -p '' "${SCRIPT_FILENAME}_XXXXX.tmp")
+trap "rm -rf '$TEMPDIR'" EXIT
+
+# Path to file recording one line per instance, with it's name, instance id, start
+# date/time separated by a space.  Exceptional conditions are recorded as comments
+# with the name and details.  File is refreshed/overwritten each time script runs
+# without any fatal/uncaught command-errors.  Intended for reference by humans
+# and/or other tooling.
+PWSTATE="${PWSTATE:-$LIB_DIRPATH/pw_status.txt}"
+
+# Name of launch template. Current/default version will be used.
+# https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#LaunchTemplates:
+TEMPLATE_NAME="${TEMPLATE_NAME:-CirrusMacM1PWinstance}"
+
+# Path to scripts to copy/execute on Darwin instances
+SETUP_SCRIPT="$LIB_DIRPATH/setup.sh"
+SPOOL_SCRIPT="$LIB_DIRPATH/service_pool.sh"
+CIENV_SCRIPT="$LIB_DIRPATH/ci_env.sh"
+
+# Set to 1 to enable debugging
+X_DEBUG="${X_DEBUG:-0}"
+
+# AWS CLI command and general args
+AWS="aws --no-paginate --output=json --color=off --no-cli-pager --no-cli-auto-prompt"
+
+# Common ssh/scp arguments
+SSH_ARGS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o CheckHostIP=no -F /dev/null -o LogLevel=ERROR -o ConnectTimeout=13"
+# ssh/scp commands to run w/ arguments
+SSH="${SSH:-ssh -n $SSH_ARGS}"  # N/B: default nulls stdin
+SCP="${SCP:-scp -q $SSH_ARGS}"
+
+# Indentation to prefix msg/warn/die messages with to assist humans understanding context.
+_I="${_I:-}"
+
+# Print details $1 (defaults to 1) calls above the caller in the stack.
+# usage e.x. $(ctx 0) - print details about current function
+#            $(ctx) - print details about current function's caller
+#            $(ctx 2) - print details about current functions's caller's caller.
+ctx() {
+    local above level
+    above=${1:-1}
+    level=$((1+$above))
+    script=$(basename ${BASH_SOURCE[$level]})
+    echo "($script:${FUNCNAME[$level]}():${BASH_LINENO[$above]})"
+}
+
+msg() { echo "${_I}${1:-No text message provided}"; }
+warn() { echo "${1:-No warning message provided}" | awk -e '{print "'"${_I}"'WARNING: "$0}' > /dev/stderr; }
+die() { echo "${1:-No error message provided}" | awk -e '{print "'"${_I}"'ERROR: "$0}' > /dev/stderr; exit 1; }
+dbg() {
+  if ((X_DEBUG)); then
+      msg "${1:-No debug message provided} $(ctx 1)" | awk -e '{print "'"${_I}"'DEBUG: "$0}' > /dev/stderr
+  fi
+}
+
+# Obtain a JSON string value by running the provided query filter (arg 1) on
+# JSON file (arg 2).  Return non-zero on jq error (1), or if value is empty
+# or null (2).  Otherwise print value and return 0.
+jq_errf="$TEMPDIR/jq_error.output"
+json_query() {
+    local value
+    local indent="         "
+    dbg "jq filter $1
+$indent on $(basename $2) $(ctx)"
+    if ! value=$(jq -r "$1" "$2" 2>"$jq_errf"); then
+        dbg "$indent error: $(<$jq_errf)"
+        return 1
+    fi
+
+    if [[ -z "$value" ]] || [[ "$value" == "null" ]]; then
+        dbg "$indent result: Empty or null"
+        return 2
+    fi
+
+    dbg "$indent result: '$value'"
+    echo "$value"
+    return 0
+}

--- a/mac_pw_pool/service_pool.sh
+++ b/mac_pw_pool/service_pool.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Launch Cirrus-CI PW Pool listener & manager process.
+# Intended to be called once from setup.sh on M1 Macs.
+# Expects configuration filepath to be passed as the first argument.
+
+set -eo pipefail
+
+msg() { echo "##### ${1:-No message message provided}"; }
+die() { echo "ERROR: ${1:-No error message provided}"; exit 1; }
+
+msg "Listener started at $(date -u -Iseconds)"
+
+[[ "$USER" == "ec2-user" ]] || \
+    die "Expecting to execute as 'ec2-user'."
+
+[[ -r "$1" ]] || \
+    die "Can't read configuration file '$1'"
+
+# For whatever reason, when this script is run through ssh, the default
+# environment isn't loaded automatically.
+. /etc/profile
+
+PWINST=$(curl -sSLf http://instance-data/latest/meta-data/tags/instance/Name)
+PWUSER=$PWINST-worker
+[[ -n "$PWINST" ]] || \
+    die "Unexpectedly empty instance name, is metadata tag access enabled?"
+
+PWCFG="$1"
+
+# CI effectively allows unmitigated access to run or host any
+# process or content on this instance as $PWUSER.  Limit the
+# potential blast-radius of any nefarious use by restricting
+# the lifetime of the instance.  If this ends up disturbing
+# a running task, Cirrus will automatically retry on another
+# available pool instance. Shutdown instance after this many
+# hours servicing the pool.  Note: It's randomized slightly
+# to prevent instances going down at similar times.
+_rndadj=$((RANDOM%8-4))  # +/- 4 hours
+PWLIFE=$((24+$_rndadj))
+
+# Configuring a launchd agent to run the worker process is a major
+# PITA and seems to require rebooting the instance.  Work around
+# this with a really hacky loop masquerading as a system service.
+# Run it in the background to allow this setup script to exit.
+# N/B: CI tasks have access to kill the pool listener process!
+expires=$(($(date -u "+%Y%m%d%H") + $PWLIFE))
+while [[ -r $PWCFG ]]; do
+    # Don't start new pool listener if it or a CI agent process exist
+    if ! pgrep -u $PWUSER -f -q "cirrus worker run" && ! pgrep -u $PWUSER -q "cirrus-ci-agent"; then
+        # FIXME: CI Tasks will execute as $PWUSER and ordinarily would have
+        # read access to config. file containing $POOLTOKEN.  While not
+        # disastrous, it's desirable to not leak possibly sensitive
+        # values.  Work around this by keeping the file unreadable by
+        # $PWUSER except for a brief period while starting up.
+        sudo chmod 0644 $PWCFG
+        msg "$(date -u -Iseconds) Starting PW pool listener as $PWUSER"
+        sudo su -l $PWUSER -c "/opt/homebrew/bin/cirrus worker run --file $PWCFG &"
+        sleep 30s  # eek!
+        sudo chmod 0600 $PWCFG
+    fi
+
+    if [[ $(date -u "+%Y%m%d%H") -ge $expires ]]; then
+        msg "$(date -u -Iseconds) Instance expired."
+        # Try not to clobber a running Task, unless it's fake.
+        if pgrep -u $PWUSER -q "cirrus-ci-agent"; then
+            msg "$(date -u -Iseconds) Shutdown paused 2h for apparent in-flight CI task."
+            # Cirrus-CI has hard-coded 2-hour max task lifetime
+            sleep $(60 * 60 * 2)
+            msg "$(date -u -Iseconds) Killing hung or nefarious CI agent older than 2h."
+            pkill -u $PWUSER "cirrus-ci-agent"
+        fi
+        msg "$(date -u -Iseconds) Executing shutdown."
+        sudo shutdown -h +1m "Automatic instance recycle after >$PWLIFE hours."
+        sleep 120
+    fi
+
+    # Avoid re-launch busy-wait
+    sleep 60
+    msg "$(date -u -Iseconds) Pool listener watcher process tick."
+done >> $HOME/setup.log 2>&1

--- a/mac_pw_pool/setup.sh
+++ b/mac_pw_pool/setup.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Setup and launch Cirrus-CI PW Pool node.  It must be called
+# with the env. var. `$POOLTOKEN` set.  It is assumed to be
+# running on a fresh AWS EC2 mac2.metal instance as `ec2-user`
+# The instance must have both "metadata" and "Allow tags in
+# metadata" options enabled.  The instance must set the
+# "terminate" option for "shutdown behavior".
+
+set -eo pipefail
+
+GVPROXY_RELEASE_URL="https://github.com/containers/gvisor-tap-vsock/releases/latest/download/gvproxy-darwin"
+
+COMPLETION_FILE="$HOME/.setup.done"
+STARTED_FILE="$HOME/.setup.started"
+
+date -u -Iseconds >> "$STARTED_FILE"
+
+msg() { echo "##### ${1:-No message message provided}"; }
+die() { echo "ERROR: ${1:-No error message provided}"; exit 1; }
+
+[[ -n "$POOLTOKEN" ]] || \
+    die "Must be called with non-empty \$POOLTOKEN set."
+
+[[ ! -r "$COMPLETION_FILE" ]] || \
+    die "Appears setup script already ran at '$(cat $COMPLETION_FILE)'.  This script should not be called twice by automation."
+
+[[ "$USER" == "ec2-user" ]] || \
+    die "Expecting to execute as 'ec2-user'."
+
+msg "Configuring paths"
+grep -q homebrew /etc/paths || \
+    echo -e "/opt/homebrew/bin\n/opt/homebrew/opt/coreutils/libexec/gnubin\n$(cat /etc/paths)" \
+        | sudo tee /etc/paths > /dev/null
+
+# For whatever reason, when this script is run through ssh, the default
+# environment isn't loaded automatically.
+. /etc/profile
+
+msg "\$PATH=$PATH"
+
+msg "Installing podman-machine, testing, and CI deps. (~2m install time)"
+if [[ ! -x /usr/local/bin/gvproxy ]]; then
+    brew tap cfergeau/crc
+    brew install go go-md2man coreutils pstree vfkit cirruslabs/cli/cirrus
+
+    # Normally gvproxy is installed along with "podman" brew.  CI Tasks
+    # on this instance will be running from source builds, so gvproxy must
+    # be install from upstream release.
+    curl -sSLfO "$GVPROXY_RELEASE_URL"
+    sudo install -o root -g staff -m 0755 gvproxy-darwin /usr/local/bin/gvproxy
+    rm gvproxy-darwin
+fi
+
+msg "Adding/Configuring PW User"
+# Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+PWINST=$(curl -sSLf http://instance-data/latest/meta-data/tags/instance/Name)
+PWUSER=$PWINST-worker
+[[ -n "$PWINST" ]] || \
+    die "Unexpectedly empty instance name, is metadata tag access enabled?"
+
+PWCFG=$(mktemp /private/tmp/${PWINST}_cfg_XXXXXXXX)
+PWLOG="/private/tmp/${PWUSER}.log"
+
+# Make host easier to identify from CI logs (default is some
+# random internal EC2 dns name).  Doesn't need to survive a
+# reboot.
+if [[ "$(uname -n)" != "$PWINST" ]]; then
+    sudo hostname $PWINST
+    sudo scutil --set HostName $PWINST
+    sudo scutil --set ComputerName $PWINST
+fi
+
+# CI effectively allows unmitigated access to run, kill,
+# or host any process or content on this instance as $PWUSER.
+# Limit the potential blast-radius of any nefarious use by
+# restricting the lifetime of the instance.  If this ends up
+# disturbing a running task, Cirrus will automatically retry
+# on another available pool instance. If none are available,
+# the task will queue indefinitely.
+#
+# Note: It takes about 3-hours total until a new instance can
+# be up/running in this one's place.
+#
+# Shutdown (and self-terminate instance after the number of hours
+# set below.  This value may be extended by 2 more hours
+# (see `service_pool.sh`).
+#
+# * Increase value to improve instance CI-utilization.
+# * Reduce value to lower instability & security risk.
+PWLIFE=22
+
+if ! id "$PWUSER" &> /dev/null; then
+    sudo sysadminctl -addUser $PWUSER
+
+    # User can't remove own pre-existing homedir crap during cleanup
+    sudo rm -rf /Users/$PWUSER/*
+    sudo rm -rf /Users/$PWUSER/.??*
+fi
+
+# FIXME: Semi-secret POOLTOKEN value should not be in this file.
+# ref: https://github.com/cirruslabs/cirrus-cli/discussions/662
+cat << EOF | sudo tee $PWCFG > /dev/null
+---
+name: "$PWINST"
+token: "$POOLTOKEN"
+log:
+  file: "${PWLOG}"
+security:
+  allowed-isolations:
+    none: {}
+EOF
+sudo chown ${USER}:staff $PWCFG
+
+# Log file is examined by the worker process launch script.
+# Ensure it exists and $PWUSER has access to it.
+touch $PWLOG
+sudo chown ${USER}:staff $PWLOG
+sudo chmod g+rw $PWLOG
+
+if ! pgrep -q -f service_pool.sh; then
+    msg "Starting listener supervisor process"
+    /var/tmp/service_pool.sh "$PWCFG" &
+    disown %-1
+else
+    msg "Warning: Listener supervisor already running"
+fi
+
+# Allow other tooling to detect this script has run successfully to completion
+date -u -Iseconds >> "$COMPLETION_FILE"


### PR DESCRIPTION
Implement a set of scripts to help with management of a Cirrus-CI persistent worker pool of M1 Mac instances on AWS EC2.

* Implement script to help monitor a set of M1 Mac dedicated hosts, creating new instances as slots become available.

* Implement a script to help monitor M1 Mac instances, deploying and executing a setup script on newly created instances.

* Implement a ssh-helper script for humans, to quickly access instances based on their EC2 instance ID.

* Implement a setup script intended to run on M1 Macs, to help configure and join them to a pre-existing worker pool.

* Implement a helper script intended to run on M1 Macs, to support developers with a CI-like environment.

* At this time, all scripts are intended for manual/human-supervised use.  Future commits may improve this and/or better support use inside automation.

* Add very basic/expedient documentation.

N/B: The majority of this content, including the EC2-side setup has been developed in a rush.  There are very likely major architecture, design, and scripting bugs and shortfalls.  Some of these may be addressed in future commits.