### PR TITLE
Workaround lengthy startup of many instances

### DIFF
--- a/mac_pw_pool/README.md
+++ b/mac_pw_pool/README.md
@@ -56,6 +56,15 @@ From a PR perspective, there is zero control over which instance you
 get.  It could easily be one somebody's previous task barfed all over
 and ruined.
 
+## Initialization
+
+When no dedicated hosts have instances running, complete creation and
+setup will take many hours.  This may be bypassed by *manually* running
+`LaunchInstances.sh --force`.  The operator should then wait 20minutes
+before *manually* running `SetupInstances.sh --force`.  This delay
+is necessary to account for the time a Mac instance takes to boot and
+become ssh-able.
+
 ## Security
 
 To thwart attempts to hijack or use instances for nefarious purposes,

--- a/mac_pw_pool/setup.sh
+++ b/mac_pw_pool/setup.sh
@@ -6,6 +6,9 @@
 # The instance must have both "metadata" and "Allow tags in
 # metadata" options enabled.  The instance must set the
 # "terminate" option for "shutdown behavior".
+#
+# Script accepts a single argument: The number of hours to
+# delay self-termination (including 0).
 
 set -eo pipefail
 
@@ -88,7 +91,8 @@ fi
 #
 # * Increase value to improve instance CI-utilization.
 # * Reduce value to lower instability & security risk.
-PWLIFE=22
+# * Additional hours argument is optional.
+PWLIFE=$((22+${1:-0}))
 
 if ! id "$PWUSER" &> /dev/null; then
     sudo sysadminctl -addUser $PWUSER
@@ -119,8 +123,8 @@ sudo chown ${USER}:staff $PWLOG
 sudo chmod g+rw $PWLOG
 
 if ! pgrep -q -f service_pool.sh; then
-    msg "Starting listener supervisor process"
-    /var/tmp/service_pool.sh "$PWCFG" &
+    msg "Starting listener supervisor process w/ ${PWLIFE}hour lifetime"
+    /var/tmp/service_pool.sh "$PWCFG" "$PWLIFE" &
     disown %-1
 else
     msg "Warning: Listener supervisor already running"


### PR DESCRIPTION
When a pool is empty of instances, the launch-stagger mechanism can introduce a substantial delay to achieving a full-pool of active workers.  This will negatively impact service availability and worker utilization - likely resulting in CI tasks queuing.

Add a simple workaround for this condition with the addition of a `--force` option.  When used, it will force instance creation on all available dedicated hosts.  Similarly it will also force instance setup, though with an extended shutdown delay timer.

Update documentation regarding this operational mode and it's purpose.