### PR TITLE
Better logging of worker expiration

### DIFF
--- a/mac_pw_pool/service_pool.sh
+++ b/mac_pw_pool/service_pool.sh
@@ -40,6 +40,8 @@ PWLIFE="$2"
 # Run it in the background to allow this setup script to exit.
 # N/B: CI tasks have access to kill the pool listener process!
 expires=$(date -u "+%Y%m%d%H" -d "+$PWLIFE hours")
+# N/B: The text below is greped for by SetupInstances.sh
+msg "$(date -u -Iseconds): Automatic instance recycle after $(date -u -Iseconds -d "+$PWLIFE hours")"
 while [[ -r $PWCFG ]]; do
     # Don't start new pool listener if it or a CI agent process exist
     if ! pgrep -u $PWUSER -f -q "cirrus worker run" && ! pgrep -u $PWUSER -q "cirrus-ci-agent"; then
@@ -57,6 +59,8 @@ while [[ -r $PWCFG ]]; do
 
     if [[ $(date -u "+%Y%m%d%H") -ge $expires ]]; then
         msg "$(date -u -Iseconds) Instance expired."
+        # Block pickup of new jobs
+        pkill -u $PWUSER -f "cirrus worker run"
         # Try not to clobber a running Task, unless it's fake.
         if pgrep -u $PWUSER -q "cirrus-ci-agent"; then
             msg "$(date -u -Iseconds) Shutdown paused 2h for apparent in-flight CI task."

--- a/mac_pw_pool/setup.sh
+++ b/mac_pw_pool/setup.sh
@@ -124,7 +124,7 @@ sudo chmod g+rw $PWLOG
 
 if ! pgrep -q -f service_pool.sh; then
     msg "Starting listener supervisor process w/ ${PWLIFE}hour lifetime"
-    /var/tmp/service_pool.sh "$PWCFG" "$PWLIFE" &
+    /var/tmp/service_pool.sh "$PWCFG" "$PWLIFE" >> "${PWLOG}" &
     disown %-1
 else
     msg "Warning: Listener supervisor already running"


### PR DESCRIPTION
It's helpful for operators to be aware of the expiration-time for workers.  Ensure this, along with any other `service_pool.sh` messages are logged.  Extract and display the logged expiration notice, or a warning if missing.  The constant log-grep is secondarily useful as indication of worker log-file manipulation.