### PR TITLE
Allow dividing DH pool based on tag name/value

### DIFF
--- a/mac_pw_pool/LaunchInstances.sh
+++ b/mac_pw_pool/LaunchInstances.sh
@@ -59,10 +59,11 @@ inst_failure() {
 }
 
 # Find dedicated hosts to operate on.
-dh_flt="Name=tag:Name,Values=MacM1-*"
+dh_name_flt="Name=tag:Name,Values=MacM1-*"
+dh_tag_flt="Name=tag:$DH_REQ_TAG,Values=$DH_REQ_VAL"
 dh_qry='Hosts[].{HostID:HostId, Name:[Tags[?Key==`Name`].Value][] | [0]}'
 dh_searchout="$TEMPDIR/hosts.output"  # JSON or error message
-if ! $AWS ec2 describe-hosts --filter "$dh_flt" --query "$dh_qry" &> "$dh_searchout"; then
+if ! $AWS ec2 describe-hosts --filter "$dh_name_flt" "$dh_tag_flt" --query "$dh_qry" &> "$dh_searchout"; then
     die "Searching for dedicated hosts $(ctx 0):
 $(<$dh_searchout)"
 fi

--- a/mac_pw_pool/pw_lib.sh
+++ b/mac_pw_pool/pw_lib.sh
@@ -10,6 +10,10 @@ LIB_DIRPATH=$(dirname "${BASH_SOURCE[0]}")
 TEMPDIR=$(mktemp -d -p '' "${SCRIPT_FILENAME}_XXXXX.tmp")
 trap "rm -rf '$TEMPDIR'" EXIT
 
+# Only manage dedicated hosts with the following tag & value
+DH_REQ_TAG="purpose"
+DH_REQ_VAL="prod"
+
 # Path to file recording the most recent state of each dedicated host.
 # Format is simply one line per dedicated host, with it's name, instance id, start
 # date/time separated by a space.  Exceptional conditions are recorded as comments


### PR DESCRIPTION
With an active and in-use dedicated host pool, it's very hard to test changes to management scripts.  Add support for filtering the list of DH to operate on, based on a defined tag name and value.  This way, inactive DH can be manually re-tagged (temporarily) to allow testing script changes against them.