### PR TITLE
Improve/overhaul pool management/monitoring scripts

### DIFF
--- a/mac_pw_pool/.gitignore
+++ b/mac_pw_pool/.gitignore
@@ -1,2 +1,4 @@
+/Cron.log
+/utilization.csv
 /dh_status.txt*
 /pw_status.txt*

--- a/mac_pw_pool/Cron.sh
+++ b/mac_pw_pool/Cron.sh
@@ -41,8 +41,9 @@ timestamp=$(date -u -Iseconds -d \
                 awk '{print $4}'))
 pw_state=$(grep -E -v '^($|#+| +)' "$PWSTATE")
 n_workers=$(grep 'complete alive' <<<"$pw_state" | wc -l)
-n_tasks=$(awk 'BEGIN{T=0} /MacM1-[0-9]+ complete alive/{T+=$4} END{print T}' <<<"$pw_state")
-printf "%s,%i,%i\n" "$timestamp" "$n_workers" "$n_tasks" | tee -a "$uzn_file"
+n_tasks=$(awk 'BEGIN{B=0} /MacM1-[0-9]+ complete alive/{B+=$4} END{print B}' <<<"$pw_state")
+n_taskf=$(awk 'BEGIN{E=0} /MacM1-[0-9]+ complete alive/{E+=$5} END{print E}' <<<"$pw_state")
+printf "%s,%i,%i,%i\n" "$timestamp" "$n_workers" "$n_tasks" "$n_taskf" | tee -a "$uzn_file"
 
 # Prevent uncontrolled growth of utilization.csv.  Assume this script
 # runs every $interval minutes, keep only $history_hours worth of data.

--- a/mac_pw_pool/InstanceSSH.sh
+++ b/mac_pw_pool/InstanceSSH.sh
@@ -4,27 +4,36 @@ set -eo pipefail
 
 # Helper for humans to access an existing instance.  It depends on:
 #
-# * You know the instance-id value.
+# * You know the instance-id or name.
 # * All requirements listed in the top `LaunchInstances.sh` comment.
 # * The local ssh-agent is able to supply the appropriate private key.
 
 # shellcheck source-path=SCRIPTDIR
 source $(dirname ${BASH_SOURCE[0]})/pw_lib.sh
 
-# Enable access to VNC if it's running
-# ref: https://repost.aws/knowledge-center/ec2-mac-instance-gui-access
-SSH="ssh $SSH_ARGS -L 5900:localhost:5900"  # N/B: library default nulls stdin
+SSH="ssh $SSH_ARGS"  # N/B: library default nulls stdin
+if nc -z localhost 5900; then
+    # Enable access to VNC if it's running
+    # ref: https://repost.aws/knowledge-center/ec2-mac-instance-gui-access
+    SSH+=" -L 5900:localhost:5900"
+fi
 
 [[ -n "$1" ]] || \
     die "Must provide EC2 instance ID as first argument"
-instance_id="${1:-EmptyID}"
+
+case "$1" in
+    i-*)
+      inst_json=$($AWS ec2 describe-instances --instance-ids "$1") ;;
+    *)
+      inst_json=$($AWS ec2 describe-instances --filter "Name=tag:Name,Values=$1") ;;
+esac
+
 shift
 
-inst_json=$($AWS ec2 describe-instances --instance-ids "$instance_id")
 pub_dns=$(jq -r -e '.Reservations?[0]?.Instances?[0]?.PublicDnsName?' <<<"$inst_json")
 if [[ -z "$pub_dns" ]] || [[ "$pub_dns" == "null" ]]; then
     die "Instance '$1' does not exist, or have a public DNS address allocated (yet)."
 fi
 
-echo "+ $SSH ec2-user@$pub_dns \"$*\"" >> /dev/stderr
-$SSH ec2-user@$pub_dns "$@"
+echo "+ $SSH ec2-user@$pub_dns $*" >> /dev/stderr
+exec $SSH ec2-user@$pub_dns "$@"

--- a/mac_pw_pool/README.md
+++ b/mac_pw_pool/README.md
@@ -57,10 +57,16 @@ and ruined.
 
 When no dedicated hosts have instances running, complete creation and
 setup will take many hours.  This may be bypassed by *manually* running
-`LaunchInstances.sh --force`.  The operator should then wait 20minutes
-before *manually* running `SetupInstances.sh --force`.  This delay
-is necessary to account for the time a Mac instance takes to boot and
-become ssh-able.
+`LaunchInstances.sh --force`.  This should be done prior to installing
+the `Cron.sh` cron-job.
+
+In order to prevent all the instances from being recycled at the same
+(future) time, the shutdown time installed by `SetupInstances.sh` also
+needs to be adjusted.  The operator should first wait about 20 minutes
+for all new instances to fully boot.  Followed by a call to
+`SetupInstances.sh --force`.
+
+Now the `Cron.sh` cron-job may be installed, enabled and started.
 
 ## Security
 

--- a/mac_pw_pool/README.md
+++ b/mac_pw_pool/README.md
@@ -68,6 +68,21 @@ for all new instances to fully boot.  Followed by a call to
 
 Now the `Cron.sh` cron-job may be installed, enabled and started.
 
+## Manual Testing
+
+Verifying changes to these scripts / cron-job must be done manually.
+To support this, every dedicated host has a `purpose` tag set, which
+must correspond to the value indicated in `pw_lib.sh`.  To test script
+changes, first create one or more dedicated hosts with a unique `purpose`
+tag (like "cevich-testing").  Then temporarily update `pw_lib.sh` to use
+that value.
+
+***Importantly***, if running test tasks against the test workers,
+ensure you also customize the `purpose` label in the `cirrus.yml` task(s).
+Without this, production tasks will get scheduled on your testing instances.
+Just be sure to revert all the `purpose` values back to `prod`
+(and destroy related dedicated hosts) before any PRs get merged.
+
 ## Security
 
 To thwart attempts to hijack or use instances for nefarious purposes,

--- a/mac_pw_pool/SetupInstances.sh
+++ b/mac_pw_pool/SetupInstances.sh
@@ -309,7 +309,7 @@ for _dhentry in "${_dhstate[@]}"; do
             # N/B: This drops .setup.started and eventually (hopefully) .setup.done
             if ! $SSH ec2-user@$pub_dns \
                     env POOLTOKEN=$POOLTOKEN \
-                    bash -c "'/var/tmp/setup.sh' </dev/null >>setup.log 2>&1 &"; then
+                    bash -c "'/var/tmp/setup.sh $DH_REQ_TAG:\ $DH_REQ_VAL' </dev/null >>setup.log 2>&1 &"; then
                 # This is critical, no easy way to determine what broke.
                 force_term "Failed to start background setup script"
                 continue

--- a/mac_pw_pool/SetupInstances.sh
+++ b/mac_pw_pool/SetupInstances.sh
@@ -6,31 +6,33 @@ set -eo pipefail
 # to provision any/all accessible Cirrus-CI Persistent Worker instances
 # as they become available.  This is intended to operate independently
 # from `LaunchInstances.sh` soas to "hide" the nearly 2-hours of cumulative
-# startup and termination wait time.  This script depends on:
+# startup and termination wait times.  This script depends on:
 #
-# * The $DHSTATE file created/updated by `LaunchInstances.sh`.
 # * All requirements listed in the top `LaunchInstances.sh` comment.
-# * The local ssh-agent is able to supply the appropriate private key.
+# * The $DHSTATE file created/updated by `LaunchInstances.sh`.
 # * The $POOLTOKEN env. var. is defined
+# * The local ssh-agent is able to supply the appropriate private key.
 
 # shellcheck source-path=SCRIPTDIR
 source $(dirname ${BASH_SOURCE[0]})/pw_lib.sh
 
 # Update temporary-dir status file for instance $name
 # status type $1 and value $2.  Where status type is
-# 'setup', 'listener', 'tasks' or 'comment'.
+# 'setup', 'listener', 'tasks', 'taskf' or 'comment'.
 set_pw_status() {
     [[ -n "$name" ]] || \
         die "Expecting \$name to be set"
     case $1 in
       setup) ;;
       listener) ;;
-      tasks) ;;
+      tasks) ;;  # started
+      taskf) ;;  # finished
+      ftasks) ;;
       comment) ;;
-      *) die "Status type must be 'setup', 'listener', 'tasks', or 'comment'"
+      *) die "Status type must be 'setup', 'listener', 'tasks', 'taskf' or 'comment'"
     esac
     if [[ "$1" != "comment" ]] && [[ -z "$2" ]]; then
-        die "Expecting status value to be non-empty."
+        die "Expecting comment text (status argument) to be non-empty."
     fi
     echo -n "$2" > $TEMPDIR/${name}.$1
 }
@@ -38,6 +40,55 @@ set_pw_status() {
 # Wrapper around msg() and warn() which also set_pw_status() comment.
 pwst_msg() { set_pw_status comment "$1"; msg "$1"; }
 pwst_warn() { set_pw_status comment "$1"; warn "$1"; }
+
+# Attempt to signal $SPOOL_SCRIPT to stop picking up new CI tasks but
+# support PWPoolReady being reset to 'true' in the future to signal
+# a new $SETUP_SCRIPT run.  Cancel future $SHDWN_SCRIPT action.
+# Requires both $pub_dns and $name are set
+stop_listener(){
+    dbg "Attempting to stop pool listener and reset setup state"
+    $SSH ec2-user@$pub_dns rm -f \
+        "/private/tmp/${name}_cfg_*" \
+        "./.setup.done" \
+        "./.setup.started" \
+        "/var/tmp/shutdown.sh"
+}
+
+# Forcibly shutdown an instance immediately, printing warning and status
+# comment from first argument.  Requires $name, $instance_id, and $pub_dns
+# to be set.
+force_term(){
+    local varname
+    local termoutput
+    termoutput="$TEMPDIR/${name}_term.output"
+    local term_msg
+    term_msg="${1:-no inst_panic() message provided} Terminating immediately! $(ctx)"
+
+    for varname in name instance_id pub_dns; do
+        [[ -n "${!varname}" ]] || \
+           die "Expecting \$$varname to be set/non-empty."
+    done
+
+    # $SSH has built-in -n; ignore failure, inst may be in broken state already
+    echo "$term_msg" | ssh $SSH_ARGS ec2-user@$pub_dns sudo wall || true
+    # Set status and print warning message
+    pwst_warn "$term_msg"
+
+    # Instance is going to be terminated, immediately stop any attempts to
+    # restart listening for jobs.  Ignore failure if unreachable for any reason -
+    # we/something else could have already started termination previously
+    stop_listener || true
+
+    # Termination can take a few minutes, block further use of instance immediately.
+    $AWS ec2 create-tags --resources $instance_id --tags "Key=PWPoolReady,Value=false" || true
+
+    # Prefer possibly recovering a broken pool over debug-ability.
+    if ! $AWS ec2 terminate-instances --instance-ids $instance_id &> "$termoutput"; then
+        # Possible if the instance recently/previously started termination process.
+        warn "Could not terminate instance $instance_id $(ctx 0):
+$(<$termoutput)"
+    fi
+}
 
 # Set non-zero to enable debugging / prevent removal of temp. dir.
 S_DEBUG="${S_DEBUG:0}"
@@ -57,7 +108,7 @@ declare -a _dhstate
 readarray -t _dhstate <<<$(grep -E -v '^($|#+| +)' "$DHSTATE" | sort)
 n_inst=0
 n_inst_total="${#_dhstate[@]}"
-if [[ $n_inst_total -eq 0 ]] || [[ -z "${_dhstate[0]}" ]]; then
+if [[ -z "${_dhstate[*]}" ]] || ! ((n_inst_total)); then
     msg "No operable hosts found in $DHSTATE:
 $(<$DHSTATE)"
     # Assume this script is running in a loop, and unf. there are
@@ -69,6 +120,19 @@ fi
 msg "Operating on $n_inst_total instances from $(head -1 $DHSTATE)"
 echo -e "# $(basename ${BASH_SOURCE[0]}) run $(date -u -Iseconds)\n#" > "$TEMPDIR/$(basename $PWSTATE)"
 
+# Previous instance state needed for some optional checks
+declare -a _pwstate
+n_pw_total=0
+if [[ -r "$PWSTATE" ]]; then
+    readarray -t _pwstate <<<$(grep -E -v '^($|#+| +)' "$PWSTATE" | sort)
+    n_pw_total="${#_pwstate[@]}"
+    # Handle single empty-item array
+    if [[ -z "${_pwstate[*]}" ]] || ! ((n_pw_total)); then
+        _pwstate=()
+        _n_pw_total=0
+    fi
+fi
+
 # Assuming the `--force` option was used to initialize a new pool of
 # workers, then instances need to be configured with a self-termination
 # shutdown delay.  This ensures future replacement instances creation
@@ -77,7 +141,7 @@ term_addtl=0
 # shellcheck disable=SC2199
 if [[ "$@" =~ --force ]]; then
     warn "Forcing instance creation: Ignoring staggered creation limits."
-    term_addtl=1  # Multiples of 2-hours to add to self-termination delay
+    term_addtl=1  # Multiples of $CREATE_STAGGER_HOURS to add to shutdown delay
 fi
 
 for _dhentry in "${_dhstate[@]}"; do
@@ -87,14 +151,19 @@ for _dhentry in "${_dhstate[@]}"; do
     n_inst=$(($n_inst+1))
     msg "Working on Instance #$n_inst/$n_inst_total '$name' with ID '$instance_id'."
 
+    # Clear buffers used for updating status files
+    n_started_tasks=0
+    n_finished_tasks=0
+
     instoutput="$TEMPDIR/${name}_inst.output"
     ncoutput="$TEMPDIR/${name}_nc.output"
-    logoutput="$TEMPDIR/${name}_ssh.output"
+    logoutput="$TEMPDIR/${name}_log.output"
 
     # Most operations below 'continue' looping on error.  Ensure status files match.
-    for status_type in setup listener tasks; do
-        set_pw_status $status_type error
-    done
+    set_pw_status tasks 0
+    set_pw_status taskf 0
+    set_pw_status setup error
+    set_pw_status listener error
     set_pw_status comment ""
 
     if ! $AWS ec2 describe-instances --instance-ids $instance_id &> "$instoutput"; then
@@ -102,34 +171,37 @@ for _dhentry in "${_dhstate[@]}"; do
         continue
     fi
 
-    # Check if instance should be managed
-    if ! PWPoolReady=$(json_query '.Reservations?[0]?.Instances?[0]?.Tags? | map(select(.Key == "PWPoolReady")) | .[].Value' "$instoutput"); then
-        pwst_warn "Instance does not have a PWPoolReady tag"
-        PWPoolReady="tag absent"
-    fi
-
-    if [[ "$PWPoolReady" != "true" ]]; then
-        pwst_msg "Instance disabled via tag 'PWPoolReady' == '$PWPoolReady' != 'true'."
+    dbg "Verifying required $DH_REQ_TAG=$DH_REQ_VAL"
+    tagq=".Reservations?[0]?.Instances?[0]?.Tags | map(select(.Key == \"$DH_REQ_TAG\")) | .[].Value"
+    if ! inst_tag=$(json_query "$tagq" "$instoutput"); then
+        pwst_warn "Could not look up instance $DH_REQ_TAG tag"
         continue
     fi
 
-    msg "Verifying lifetime <3 days (launched '$launch_time')"
-    # It's really important that instances have a defined and risk-relative
-    # short lifespan.  Multiple mechanisms are in place to assist, but none
-    # are perfect.  Warn operators if any instance has been alive "too long".
-    now=$(date -u +%Y%m%d)
-    then=$(date -u -d "$launch_time" +%Y%m%d)
-    # c/automation_images Cirrus-CI job terminates EC2 instances after 3 days
-    [[ $((now-then)) -le 3 ]] || \
-        pwst_warn "Excess instance lifetime, please investigate $(ctx 0)"
+    if [[ "$inst_tag" != "$DH_REQ_VAL" ]]; then
+        pwst_warn "Required inst. '$DH_REQ_TAG' tag != '$DH_REQ_VAL'"
+        continue
+    fi
 
-    msg "Looking up public DNS"
+    dbg "Looking up instance name"
+    nameq='.Reservations?[0]?.Instances?[0]?.Tags | map(select(.Key == "Name")) | .[].Value'
+    if ! inst_name=$(json_query "$nameq" "$instoutput"); then
+        pwst_warn "Could not look up instance Name tag"
+        continue
+    fi
+
+    if [[ "$inst_name" != "$name" ]]; then
+        pwst_warn "Inst. name '$inst_name' != DH name '$name'"
+        continue
+    fi
+
+    dbg "Looking up public DNS"
     if ! pub_dns=$(json_query '.Reservations?[0]?.Instances?[0]?.PublicDnsName?' "$instoutput"); then
         pwst_warn "Could not lookup of public DNS for instance $instance_id $(ctx 0)"
         continue
     fi
 
-    msg "Attempting to contact '$name' at $pub_dns"
+    dbg "Attempting to contact '$name' at $pub_dns"
     if ! nc -z -w 13 $pub_dns 22 &> "$ncoutput"; then
         pwst_warn "Could not connect to port 22 on '$pub_dns' $(ctx 0)."
         continue
@@ -140,107 +212,206 @@ for _dhentry in "${_dhstate[@]}"; do
         continue
     fi
 
-    msg "Checking state of instance"
+    dbg "Check if instance should be managed"
+    if ! PWPoolReady=$(json_query '.Reservations?[0]?.Instances?[0]?.Tags? | map(select(.Key == "PWPoolReady")) | .[].Value' "$instoutput"); then
+        pwst_warn "Instance does not have a PWPoolReady tag"
+        PWPoolReady="absent"
+    fi
+
+    # Mechanism for a developer to manually debug operations w/o fear of new tasks or instance shutdown.
+    if [[ "$PWPoolReady" != "true" ]]; then
+        pwst_msg "Instance disabled via tag 'PWPoolReady' == '$PWPoolReady'."
+        set_pw_status setup disabled
+        set_pw_status listener disabled
+        (
+            set +e  # All commands below are best-effort only!
+            dbg "Attempting to stop any pending shutdowns"
+            $SSH ec2-user@$pub_dns sudo pkill shutdown
+
+            stop_listener
+
+            dbg "Attempting to stop shutdown sleep "
+            $SSH ec2-user@$pub_dns pkill -u ec2-user -f "'bash -c sleep'"
+
+            if $SSH ec2-user@$pub_dns pgrep -u ec2-user -f service_pool.sh; then
+                sleep 10s  # Allow service_pool to exit gracefully
+            fi
+
+            # N/B: This will not stop any currently running CI tasks.
+            dbg "Guarantee pool listener is dead"
+            $SSH ec2-user@$pub_dns sudo pkill -u ${name}-worker -f "'cirrus worker run'"
+        )
+        continue
+    fi
+
+    # It's really important that instances have a defined and risk-relative
+    # short lifespan.  Multiple mechanisms are in place to assist, but none
+    # are perfect.  Ensure instances running for an excessive time are forcefully
+    # terminated as soon as possible from this script.
+    launch_epoch=$(date -u -d "$launch_time" +%s)
+    now_epoch=$(date -u +%s)
+    age_sec=$((now_epoch-launch_epoch))
+    hard_max_sec=$((PW_MAX_HOURS*60*60*2))  # double PW_MAX_HOURS
+    dbg "launch_epoch=$launch_epoch"
+    dbg "   now_epoch=$now_epoch"
+    dbg "     age_sec=$age_sec"
+    dbg "hard_max_sec=$hard_max_sec"
+    msg "Instance alive for $((age_sec/60/60)) hours (max $PW_MAX_HOURS)"
+    if [[ $age_sec -gt $hard_max_sec ]]; then
+        force_term "Excess instance lifetime (+$((age_sec-hard_max_sec))s)"
+        continue
+    fi
+
     if ! $SSH ec2-user@$pub_dns test -r .setup.done; then
 
         if ! $SSH ec2-user@$pub_dns test -r .setup.started; then
             if $SSH ec2-user@$pub_dns test -r setup.log; then
+                # Can be caused by operator flipping PWPoolReady value on instance for debugging
                 pwst_warn "Setup log found, prior executions may have failed $(ctx 0)."
             fi
 
             pwst_msg "Setting up new instance"
 
-            # Switch to bash for consistency && some ssh commands below
+            # Ensure bash used for consistency && some ssh commands below
             # don't play nicely with zsh.
             $SSH ec2-user@$pub_dns sudo chsh -s /bin/bash ec2-user &> /dev/null
 
-            if ! $SCP $SETUP_SCRIPT $SPOOL_SCRIPT ec2-user@$pub_dns:/var/tmp/; then
+            if ! $SCP $SETUP_SCRIPT $SPOOL_SCRIPT $SHDWN_SCRIPT ec2-user@$pub_dns:/var/tmp/; then
                 pwst_warn "Could not scp scripts to instance $(ctx 0)."
-                continue
+                continue  # try again next loop
             fi
 
             if ! $SCP $CIENV_SCRIPT ec2-user@$pub_dns:./; then
                 pwst_warn "Could not scp CI Env. script to instance $(ctx 0)."
-                continue
+                continue  # try again next loop
             fi
 
-            if ! $SSH ec2-user@$pub_dns chmod +x /var/tmp/*.sh; then
+            if ! $SSH ec2-user@$pub_dns chmod +x "/var/tmp/*.sh" "./ci_env.sh"; then
                 pwst_warn "Could not chmod scripts $(ctx 0)."
+                continue  # try again next loop
+            fi
+
+            shutdown_seconds=$((60*60*term_addtl*CREATE_STAGGER_HOURS + 60*60*PW_MAX_HOURS))
+            pwst_msg "Starting automatic instance recycling in $((term_addtl*CREATE_STAGGER_HOURS + PW_MAX_HOURS)) hours"
+            # Darwin is really weird WRT active terminals and the shutdown
+            # command.  Instead of installing a future shutdown, stick an
+            # immediate shutdown at the end of a long sleep. This is the
+            # simplest workaround I could find :S
+            # Darwin sleep only accepts seconds.
+            if ! $SSH ec2-user@$pub_dns bash -c \
+                "'sleep $shutdown_seconds && /var/tmp/shutdown.sh' </dev/null >>setup.log 2>&1 &"; then
+                pwst_warn "Could not start automatic instance recycling."
+                continue  # try again next loop
+            fi
+
+            pwst_msg "Executing setup script."
+            # Run setup script in background b/c it takes ~10m to complete.
+            # N/B: This drops .setup.started and eventually (hopefully) .setup.done
+            if ! $SSH ec2-user@$pub_dns \
+                    env POOLTOKEN=$POOLTOKEN \
+                    bash -c "'/var/tmp/setup.sh' </dev/null >>setup.log 2>&1 &"; then
+                # This is critical, no easy way to determine what broke.
+                force_term "Failed to start background setup script"
                 continue
             fi
 
-            dbg "Additional term-delay hours: $term_addtl"
-
-            # Run setup script in background b/c it takes ~5-10m to complete.
-            $SSH ec2-user@$pub_dns \
-                env POOLTOKEN=$POOLTOKEN \
-                bash -c "/var/tmp/setup.sh $(($term_addtl * 2)) &> setup.log & disown %-1"
-
-            msg "Setup script started w/ $(($term_addtl * 2))hour(s) additional shutdown delay"
+            msg "Setup script started."
             set_pw_status setup started
 
-            # When starting multiple instance, force self-termination staggering.
-            term_addtl=$(($term_addtl+1))
+            # If starting multiple instance for any reason, stagger shutdowns.
+            term_addtl=$((term_addtl+1))
 
-            # Let it run in the background
+            # Let setup run in the background
             continue
         fi
 
-        since=$($SSH ec2-user@$pub_dns tail -1 .setup.started)
-        msg "Setup not complete;  Now: $(date -u -Iseconds)"
-        pwst_msg "Setup running since:      $since"
+        # Setup started in previous loop.  Set to epoch on error.
+        since_timestamp=$($SSH ec2-user@$pub_dns tail -1 .setup.started || echo "@0")
+        since_epoch=$(date -u -d "$since_timestamp" +%s)
+        running_seconds=$((now_epoch-since_epoch))
+        # Be helpful to human monitors, show the last few lines from the log to help
+        # track progress and/or any errors/warnings.
+        pwst_msg "Setup incomplete;  Running for $((running_seconds/60)) minutes (~10 typical)"
+        msg "setup.log tail: $($SSH ec2-user@$pub_dns tail -n 1 setup.log)"
+        if [[ $running_seconds -gt $SETUP_MAX_SECONDS ]]; then
+            force_term "Setup running for ${running_seconds}s, max ${SETUP_MAX_SECONDS}s."
+        fi
         continue
     fi
 
-    msg "Instance setup has completed"
+    dbg "Instance setup has completed"
     set_pw_status setup complete
 
-    if ! $SSH ec2-user@$pub_dns pgrep -u "${name}-worker" -f -q "cirrus worker run"; then
-        pwst_warn "Cirrus worker listener process is not running $(ctx 0)."
-        set_pw_status listener dead
+    # Spawned by setup.sh
+    dbg "Checking service_pool.sh script"
+    if ! $SSH ec2-user@$pub_dns pgrep -u ec2-user -q -f service_pool.sh; then
+        # This should not happen at this stage; Nefarious or uncontrolled activity?
+        force_term "Pool servicing script (service_pool.sh) is not running."
         continue
     fi
 
-    msg "Cirrus worker listener process is running"
+    dbg "Checking cirrus listener"
+    state_fault=0
+    if ! $SSH ec2-user@$pub_dns pgrep -u "${name}-worker" -q -f "'cirrus worker run'"; then
+        # Don't try to examine prior state if there was none.
+        if ((n_pw_total)); then
+            for _pwentry in "${_pwstate[@]}"; do
+                read -r _name _setup_state _listener_state _tasks _taskf _junk <<<"$_pwentry"
+                dbg "Examining pw_state.txt entry '$_name' with listener state '$_listener_state'"
+                if [[ "$_name" == "$name" ]] && [[ "$_listener_state" != "alive" ]]; then
+                    # service_pool.sh did not restart listener since last loop
+                    # and node is not in maintenance mode (PWPoolReady == 'true')
+                    force_term "Pool listener '$_listener_state' state fault."
+                    state_fault=1
+                    break
+                fi
+            done
+        fi
 
-    logpath="/private/tmp/${name}-worker.log"  # set in setup.sh
-    # The log output from "cirrus worker run" only records task starts
-    if ! $SSH ec2-user@$pub_dns "cat $logpath" &> "$logoutput"; then
-        pwst_warn "Missing worker log $logpath"
+        # The instance is in the process of shutting-down/terminating, move on to next instance.
+        if ((state_fault)); then
+            continue
+        fi
+
+        # Previous state didn't exist, or listener status was 'alive'.
+        # Process may have simply crashed, allow service_pool.sh time to restart it.
+        pwst_warn "Cirrus worker listener process NOT running, will recheck again $(ctx 0)."
+        # service_pool.sh should catch this and restart the listener. If not, the next time
+        # through this loop will force_term() the instance.
+        set_pw_status listener dead  # service_pool.sh should restart listener
+        continue
     else
-        dbg "worker log:
-$(<$logoutput)"
+        set_pw_status listener alive
     fi
 
+    dbg "Checking worker log"
+    logpath="/private/tmp/${name}-worker.log"  # set in setup.sh
+    if ! $SSH ec2-user@$pub_dns cat "'$logpath'" &> "$logoutput"; then
+        # The "${name}-worker" user has write access to this log
+        force_term "Missing worker log $logpath."
+        continue
+    fi
+
+    dbg "Checking worker registration"
     # First lines of log should always match this
     if ! head -10 "$logoutput" | grep -q 'worker successfully registered'; then
-        warn "Expecting successful registration log entry:
-$(head -1 "$logoutput")"
-        continue
-    fi
-
-    msg "Cirrus worker listener successfully registered at least once"
-    set_pw_status listener alive
-
-    # Most of the time these are harmless, "can't connect" flakes.
-    if grep -Eq 'level=error.+msg.+failed' "$logoutput"; then
-        warn "Failure messages present in worker log"
-    fi
-
-    if ! autoexp=$(grep -Eh -m1 '.+: Automatic instance recycle after .+' "$logoutput"); then
-        # Unusual but non-consequential, warn and move on.
-        warn "No auto-expire notice found in log."
-    elif [[ -n "$autoexp" ]]; then
-        # msg() prefixes everything with '#####' automatically.
-        nopfx=$(cut -d ' ' -f 3- <<<"$autoexp")
-        msg "$nopfx"
+        # This could signal log manipulation by worker user, or it could be harmless.
+        pwst_warn "Missing registration log entry"
     fi
 
     # The CI user has write-access to this log file on the instance,
     # make this known to humans in case they care.
-    n_tasks=$(grep -Ei 'started' "$logoutput" | wc -l) || true
-    msg "Apparent worker task executions: $n_tasks"
-    set_pw_status tasks $n_tasks
+    n_started_tasks=$(grep -Ei 'started task [0-9]+' "$logoutput" | wc -l) || true
+    n_finished_tasks=$(grep -Ei 'task [0-9]+ completed' "$logoutput" | wc -l) || true
+    set_pw_status tasks $n_started_tasks
+    set_pw_status taskf $n_finished_tasks
+
+    msg "Apparent tasks started/finished/running: $n_started_tasks $n_finished_tasks $((n_started_tasks-n_finished_tasks)) (max $PW_MAX_TASKS)"
+
+    dbg "Checking apparent task limit"
+    if [[ "$n_finished_tasks" -gt $PW_MAX_TASKS ]]; then
+        force_term "Instance exceeded $PW_MAX_TASKS apparent tasks."
+    fi
 done
 
 _I=""
@@ -252,11 +423,12 @@ for _dhentry in "${_dhstate[@]}"; do
     _f2=$(<$TEMPDIR/${name}.setup)
     _f3=$(<$TEMPDIR/${name}.listener)
     _f4=$(<$TEMPDIR/${name}.tasks)
-    _f5=$(<$TEMPDIR/${name}.comment)
-    [[ -z "$_f5" ]] || _f5=" # $_f5"
+    _f5=$(<$TEMPDIR/${name}.taskf)
+    _f6=$(<$TEMPDIR/${name}.comment)
+    [[ -z "$_f6" ]] || _f6=" # $_f6"
 
-    printf '%s %s %s %s%s\n' \
-      "$_f1" "$_f2" "$_f3" "$_f4" "$_f5" >> "$TEMPDIR/$(basename $PWSTATE)"
+    printf '%s %s %s %s %s%s\n' \
+      "$_f1" "$_f2" "$_f3" "$_f4" "$_f5" "$_f6" >> "$TEMPDIR/$(basename $PWSTATE)"
 done
 
 dbg "Creating/updating state file"

--- a/mac_pw_pool/Utilization.gnuplot
+++ b/mac_pw_pool/Utilization.gnuplot
@@ -9,17 +9,17 @@ set title "Persistent Workers & Utilization"
 
 set xdata time
 set timefmt "%Y-%m-%dT%H:%M:%S+00:00"
-set xtics rotate timedate
+set xtics nomirror rotate timedate
 set xlabel "time/date"
-set xrange [(system("date -u -Iseconds -d '6 hours ago'")):(system("date -u -Iseconds"))]
+set xrange [(system("date -u -Iseconds -d '26 hours ago'")):(system("date -u -Iseconds"))]
 
 set ylabel "Workers Online"
-set ytics border numeric
-set yrange [0:10]
+set ytics border nomirror numeric
+set yrange [0:(system("grep 'MacM1' dh_status.txt | wc -l") * 1.5)]
 
 set y2label "Worker Utilization"
-set y2tics border numeric
-set y2range [0:50]
+set y2tics border nomirror numeric
+set y2range [0:100]
 
 set datafile separator comma
 set grid
@@ -27,11 +27,14 @@ set grid
 plot 'utilization.csv' using 1:2 title "# Workers" with points pt 7, \
      '' using 1:($3/$2) axis x1y2 title "Tasks/Worker" with lines lw 2
 
+plot 'utilization.csv' using 1:2                  axis x1y1 title "Workers"     with dots lw 5, \
+                    '' using 1:((($3-$4)/$2)*100) axis x1y2 title "Utilization" with lines lw 2
+
 while GPVAL_SYSTEM_ERRNO==0 {
-    system "sleep 30s"
-    set xrange [(system("date -u -Iseconds -d '6 hours ago'")):(system("date -u -Iseconds"))]
-    set yrange [0:10]
-    set y2range [0:50]
+    system "sleep 5s"
+    # These change over time, make sure they're updated before 'replot'
+    set xrange [(system("date -u -Iseconds -d '26 hours ago'")):(system("date -u -Iseconds"))]
+    set yrange [0:(system("grep 'MacM1' dh_status.txt | wc -l") * 1.5)]
     replot
     refresh
 }

--- a/mac_pw_pool/pw_lib.sh
+++ b/mac_pw_pool/pw_lib.sh
@@ -21,15 +21,32 @@ DH_REQ_VAL="prod"
 # without any fatal/uncaught command-errors.  Intended for reference by humans
 # and/or other tooling.
 DHSTATE="${PWSTATE:-$LIB_DIRPATH/dh_status.txt}"
+
 # Similar to $DHSTATE but records the status of each instance.  Format is
-# instance name, setup status, listener status, and apparent # tasks executed
+# instance name, setup status, listener status, # started tasks, # finished tasks,
 # or the word 'error' indicating a fault accessing the remote worker logfile.
 # Optionally, there may be a final comment field, beginning with a # and text
 # suggesting where there may be a fault.
 # Possible status field values are as follows:
-#   setup - started, complete, error
-#   listener - alive, dead, error
+#   setup - started, complete, disabled, error
+#   listener - alive, dead, disabled, error
 PWSTATE="${PWSTATE:-$LIB_DIRPATH/pw_status.txt}"
+
+# At maximum possible creation-speed, there's aprox. 2-hours of time between
+# an instance going down, until another can be up and running again.  Since
+# instances are all on shutdown/terminated on pre-set timers, it would hurt
+# pool availability if multiple instances all went down at the same time.
+# Therefore, host and instance creations will be staggered by according
+# to this interval.
+CREATE_STAGGER_HOURS=2
+
+# Instance shutdown controls (assumes terminate-on-shutdown behavior)
+PW_MAX_HOURS=24  # Since successful configuration
+PW_MAX_TASKS=30  # Logged by listener (N/B: Can be manipulated by tasks!)
+
+# How long to wait for setup.sh to finish running (drop a .setup.done file)
+# before forcibly terminating.
+SETUP_MAX_SECONDS=1200  # Typical time ~600seconds
 
 # Name of launch template. Current/default version will be used.
 # https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#LaunchTemplates:
@@ -38,6 +55,7 @@ TEMPLATE_NAME="${TEMPLATE_NAME:-CirrusMacM1PWinstance}"
 # Path to scripts to copy/execute on Darwin instances
 SETUP_SCRIPT="$LIB_DIRPATH/setup.sh"
 SPOOL_SCRIPT="$LIB_DIRPATH/service_pool.sh"
+SHDWN_SCRIPT="$LIB_DIRPATH/shutdown.sh"
 CIENV_SCRIPT="$LIB_DIRPATH/ci_env.sh"
 
 # Set to 1 to enable debugging

--- a/mac_pw_pool/service_pool.sh
+++ b/mac_pw_pool/service_pool.sh
@@ -11,69 +11,69 @@ set -o pipefail
 msg() { echo "##### ${1:-No message message provided}"; }
 die() { echo "ERROR: ${1:-No error message provided}"; exit 1; }
 
-msg "Listener started at $(date -u -Iseconds)"
+for varname in PWCFG PWUSER PWREADYURL PWREADY; do
+    varval="${!varname}"
+    [[ -n "$varval" ]] || \
+        die "Env. var. \$$varname is unset/empty."
+done
 
 [[ "$USER" == "ec2-user" ]] || \
     die "Expecting to execute as 'ec2-user'."
 
-[[ -r "$1" ]] || \
-    die "Can't read configuration file '$1'"
-
-[[ -n "$2" ]] || \
-    die "Expecting shutdown delay hours as second argument"
+# All operations assume this CWD
+cd $HOME
 
 # For whatever reason, when this script is run through ssh, the default
 # environment isn't loaded automatically.
 . /etc/profile
 
-PWINST=$(curl -sSLf http://instance-data/latest/meta-data/tags/instance/Name)
-PWUSER=$PWINST-worker
-[[ -n "$PWINST" ]] || \
-    die "Unexpectedly empty instance name, is metadata tag access enabled?"
-
-PWCFG="$1"
-PWLIFE="$2"
+# This can be leftover under certain conditions
+# shellcheck disable=SC2154
+sudo pkill -u $PWUSER -f "cirrus worker run" || true
 
 # Configuring a launchd agent to run the worker process is a major
 # PITA and seems to require rebooting the instance.  Work around
 # this with a really hacky loop masquerading as a system service.
-# Run it in the background to allow this setup script to exit.
-# N/B: CI tasks have access to kill the pool listener process!
-expires=$(date -u "+%Y%m%d%H" -d "+$PWLIFE hours")
-# N/B: The text below is greped for by SetupInstances.sh
-msg "$(date -u -Iseconds): Automatic instance recycle after $(date -u -Iseconds -d "+$PWLIFE hours")"
-while [[ -r $PWCFG ]]; do
-    # Don't start new pool listener if it or a CI agent process exist
-    if ! pgrep -u $PWUSER -f -q "cirrus worker run" && ! pgrep -u $PWUSER -q "cirrus-ci-agent"; then
+# envar exported to us
+# shellcheck disable=SC2154
+while [[ -r $PWCFG ]] && [[ "$PWREADY" == "true" ]]; do  # Remove file or change tag to shutdown this "service"
+    # The $PWUSER has access to kill it's own listener, or it could crash.
+    if ! pgrep -u $PWUSER -f -q "cirrus worker run"; then
         # FIXME: CI Tasks will execute as $PWUSER and ordinarily would have
-        # read access to config. file containing $POOLTOKEN.  While not
-        # disastrous, it's desirable to not leak possibly sensitive
+        # read access to $PWCFG file containing $POOLTOKEN.  While not
+        # disastrous, it's desirable to not leak potentially sensitive
         # values.  Work around this by keeping the file unreadable by
         # $PWUSER except for a brief period while starting up.
         sudo chmod 0644 $PWCFG
         msg "$(date -u -Iseconds) Starting PW pool listener as $PWUSER"
-        sudo su -l $PWUSER -c "/opt/homebrew/bin/cirrus worker run --file $PWCFG &"
+        # This is intended for user's setup.log
+        # shellcheck disable=SC2024
+        sudo su -l $PWUSER -c "/opt/homebrew/bin/cirrus worker run --file $PWCFG &" >>setup.log 2>&1 &
         sleep 10  # eek!
         sudo chmod 0600 $PWCFG
     fi
 
-    if [[ $(date -u "+%Y%m%d%H") -ge $expires ]]; then
-        msg "$(date -u -Iseconds) Instance expired."
-        # Block pickup of new jobs
-        sudo pkill -u $PWUSER -f "cirrus worker run"
-        # Try not to clobber a running Task, unless it's fake.
-        if pgrep -u $PWUSER -q "cirrus-ci-agent"; then
-            msg "$(date -u -Iseconds) Shutdown paused 2h for apparent in-flight CI task."
-            # Cirrus-CI has hard-coded 2-hour max task lifetime
-            sleep $((60 * 60 * 2))
-            msg "$(date -u -Iseconds) Killing hung or nefarious CI agent older than 2h."
-            sudo pkill -u $PWUSER "cirrus-ci-agent"
-        fi
-        msg "$(date -u -Iseconds) Executing shutdown."
-        sudo shutdown -h now "Automatic instance recycle after >$PWLIFE hours." < /dev/null
+    # This can fail on occasion for some reason
+    # envar exported to us
+    # shellcheck disable=SC2154
+    if ! PWREADY=$(curl -sSLf $PWREADYURL); then
+        PWREADY="recheck"
     fi
 
     # Avoid re-launch busy-wait
-    sleep 60
-    msg "$(date -u -Iseconds) Pool listener watcher process tick."
-done >> $HOME/setup.log 2>&1
+    sleep 10
+
+    # Second-chance
+    if [[ "$PWREADY" == "recheck" ]] && ! PWREADY=$(curl -sSLf $PWREADYURL); then
+        msg "Failed twice to obtain PWPoolReady instance tag.  Disabling listener."
+        rm -f "$PWCFG"
+        break
+    fi
+done
+
+set +e
+
+msg "Configuration file not readable; PWPoolReady tag '$PWREADY'."
+msg "Terminating $PWUSER PW pool listner process"
+# N/B: This will _not_ stop the cirrus agent (i.e. a running task)
+sudo pkill -u $PWUSER -f "cirrus worker run"

--- a/mac_pw_pool/setup.sh
+++ b/mac_pw_pool/setup.sh
@@ -6,30 +6,53 @@
 # The instance must have both "metadata" and "Allow tags in
 # metadata" options enabled.  The instance must set the
 # "terminate" option for "shutdown behavior".
-#
-# Script accepts a single argument: The number of hours to
-# delay self-termination (including 0).
 
 set -eo pipefail
 
 GVPROXY_RELEASE_URL="https://github.com/containers/gvisor-tap-vsock/releases/latest/download/gvproxy-darwin"
-
-COMPLETION_FILE="$HOME/.setup.done"
 STARTED_FILE="$HOME/.setup.started"
+COMPLETION_FILE="$HOME/.setup.done"
 
-date -u -Iseconds >> "$STARTED_FILE"
+# Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+PWNAME=$(curl -sSLf http://instance-data/latest/meta-data/tags/instance/Name)
+PWREADYURL="http://instance-data/latest/meta-data/tags/instance/PWPoolReady"
+PWREADY=$(curl -sSLf $PWREADYURL)
+
+PWUSER=$PWNAME-worker
+rm -f /private/tmp/*_cfg_*
+PWCFG=$(mktemp /private/tmp/${PWNAME}_cfg_XXXXXXXX)
+PWLOG="/private/tmp/${PWUSER}.log"
 
 msg() { echo "##### ${1:-No message message provided}"; }
 die() { echo "ERROR: ${1:-No error message provided}"; exit 1; }
+
+die_if_empty() {
+    local tagname
+    tagname="$1"
+    [[ -n "$tagname" ]] || \
+        die "Unexpectedly empty instance '$tagname' tag, is metadata tag access enabled?"
+}
 
 [[ -n "$POOLTOKEN" ]] || \
     die "Must be called with non-empty \$POOLTOKEN set."
 
 [[ ! -r "$COMPLETION_FILE" ]] || \
-    die "Appears setup script already ran at '$(cat $COMPLETION_FILE)'.  This script should not be called twice by automation."
+    die "Appears setup script already ran at '$(cat $COMPLETION_FILE)'"
 
 [[ "$USER" == "ec2-user" ]] || \
     die "Expecting to execute as 'ec2-user'."
+
+die_if_empty PWNAME
+die_if_empty PWREADY
+
+[[ "$PWREADY" == "true" ]] || \
+    die "Found PWPoolReady tag not set 'true', aborting setup."
+
+# All operations assume this CWD
+cd $HOME
+
+# Checked by instance launch script to monitor setup status & progress
+msg $(date -u -Iseconds | tee "$STARTED_FILE")
 
 msg "Configuring paths"
 grep -q homebrew /etc/paths || \
@@ -39,8 +62,6 @@ grep -q homebrew /etc/paths || \
 # For whatever reason, when this script is run through ssh, the default
 # environment isn't loaded automatically.
 . /etc/profile
-
-msg "\$PATH=$PATH"
 
 msg "Installing podman-machine, testing, and CI deps. (~2m install time)"
 if [[ ! -x /usr/local/bin/gvproxy ]]; then
@@ -55,58 +76,31 @@ if [[ ! -x /usr/local/bin/gvproxy ]]; then
     rm gvproxy-darwin
 fi
 
-msg "Adding/Configuring PW User"
-# Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-PWINST=$(curl -sSLf http://instance-data/latest/meta-data/tags/instance/Name)
-PWUSER=$PWINST-worker
-[[ -n "$PWINST" ]] || \
-    die "Unexpectedly empty instance name, is metadata tag access enabled?"
-
-PWCFG=$(mktemp /private/tmp/${PWINST}_cfg_XXXXXXXX)
-PWLOG="/private/tmp/${PWUSER}.log"
-
+msg "Setting up hostname"
 # Make host easier to identify from CI logs (default is some
-# random internal EC2 dns name).  Doesn't need to survive a
-# reboot.
-if [[ "$(uname -n)" != "$PWINST" ]]; then
-    sudo hostname $PWINST
-    sudo scutil --set HostName $PWINST
-    sudo scutil --set ComputerName $PWINST
+# random internal EC2 dns name).
+if [[ "$(uname -n)" != "$PWNAME" ]]; then
+    sudo hostname $PWNAME
+    sudo scutil --set HostName $PWNAME
+    sudo scutil --set ComputerName $PWNAME
 fi
 
-# CI effectively allows unmitigated access to run, kill,
-# or host any process or content on this instance as $PWUSER.
-# Limit the potential blast-radius of any nefarious use by
-# restricting the lifetime of the instance.  If this ends up
-# disturbing a running task, Cirrus will automatically retry
-# on another available pool instance. If none are available,
-# the task will queue indefinitely.
-#
-# Note: It takes about 3-hours total until a new instance can
-# be up/running in this one's place.
-#
-# Shutdown (and self-terminate instance after the number of hours
-# set below.  This value may be extended by 2 more hours
-# (see `service_pool.sh`).
-#
-# * Increase value to improve instance CI-utilization.
-# * Reduce value to lower instability & security risk.
-# * Additional hours argument is optional.
-PWLIFE=$((22+${1:-0}))
-
+msg "Adding/Configuring PW User"
 if ! id "$PWUSER" &> /dev/null; then
     sudo sysadminctl -addUser $PWUSER
-
     # User can't remove own pre-existing homedir crap during cleanup
     sudo rm -rf /Users/$PWUSER/*
     sudo rm -rf /Users/$PWUSER/.??*
+    sudo pkill -u $PWUSER || true
 fi
 
 # FIXME: Semi-secret POOLTOKEN value should not be in this file.
+# TODO: It would be nice to label these based on instance's $DH_REQ_TAG: $DH_REQ_VAL
+#       as that would allow targeting PRs against (for example) a temp. testing pool.
 # ref: https://github.com/cirruslabs/cirrus-cli/discussions/662
 cat << EOF | sudo tee $PWCFG > /dev/null
 ---
-name: "$PWINST"
+name: "$PWNAME"
 token: "$POOLTOKEN"
 log:
   file: "${PWLOG}"
@@ -116,19 +110,23 @@ security:
 EOF
 sudo chown ${USER}:staff $PWCFG
 
-# Log file is examined by the worker process launch script.
-# Ensure it exists and $PWUSER has access to it.
-touch $PWLOG
+# Monitored by instance launch script
+echo "# Log created $(date -u -Iseconds) - do not manually remove or modify!" > $PWLOG
 sudo chown ${USER}:staff $PWLOG
 sudo chmod g+rw $PWLOG
 
 if ! pgrep -q -f service_pool.sh; then
-    msg "Starting listener supervisor process w/ ${PWLIFE}hour lifetime"
-    /var/tmp/service_pool.sh "$PWCFG" "$PWLIFE" >> "${PWLOG}" &
+    # Allow service_pool.sh access to these values
+    export PWCFG
+    export PWUSER
+    export PWREADYURL
+    export PWREADY
+    msg "Spawning listener supervisor process."
+    /var/tmp/service_pool.sh </dev/null >>setup.log 2>&1 &
     disown %-1
 else
     msg "Warning: Listener supervisor already running"
 fi
 
-# Allow other tooling to detect this script has run successfully to completion
+# Monitored by instance launch script
 date -u -Iseconds >> "$COMPLETION_FILE"

--- a/mac_pw_pool/shutdown.sh
+++ b/mac_pw_pool/shutdown.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Script intended to be called by automation only.
+# Should never be called from any other context.
+
+# Log on the off-chance it somehow helps somebody debug something one day
+(
+
+echo "Starting ${BASH_SOURCE[0]} at $(date -u -Iseconds)"
+
+PWNAME=$(uname -n)
+PWUSER=$PWNAME-worker
+
+if id -u "$PWUSER" &> /dev/null; then
+    # Try to not reboot while a CI task is running.
+    # Cirrus-CI imposes a hard-timeout of 2-hours.
+    now=$(date -u +%s)
+    timeout_at=$((now+60*60*2))
+    echo "Waiting up to 2 hours for any pre-existing cirrus agent (i.e. running task)"
+    while pgrep -u $PWUSER -q -f "cirrus-ci-agent"; do
+        echo "Found cirrus-ci-agent still running, waiting..."
+        sleep 60
+    done
+fi
+
+echo "Initiating shutdown at $(date -u -Iseconds)"
+
+# This script is run with a sleep in front of it
+# as a workaround for darwin's shutdown-command
+# terminal weirdness.
+
+sudo shutdown -h now "Automatic instance recycling"
+
+) < /dev/null >> setup.log 2>&1


### PR DESCRIPTION
The initial implementation was rushed into production with a minimum of
required features, and necessary amount of slop and bugs.  Attend to
a litany of needed improvements and enhancements:

* Add tracking of both started and completed tasks.
* Update utilization CSV entry addition to include tasks-ended
  (`taskS`).
* Update instance-ssh helper to support specifying by name or ID
* Fix multiple instance-ssh helper executions clashing over VNC port
  forwards.
* Update many comments
* Fix handling of case where no dedicated hosts or instances are found.
* Relocate `CREATE_STAGGER_HOURS` to `pw_lib.sh` and lower value to 2.
  This value should not include a margin representing boot/setup time.
  Also a lower value will allow for faster automated pool recovery
  should the entire thing collapse for some reason.
* Support dividing/managing a subset of all dedicated hosts and
  instances via a required tag and value.  This allows for easier
  testing of script changes w/o affecting the in-use (production) pool.
* Add check to confirm host name always matches instance name - in case
  a human screws this up.  Many/most of these management scripts
  otherwise assume the two name-tags always match.
* Update documentation for initializing a new set of dedicated hosts and
  instances.
* Forcibly terminate instances when certain exceptionally "bad" conditions
  are detected.  i.e. those which may signal a security breach or other
  issue the scripts will never be able to cope with.
* Add support for yanking an instance out of service by changing it's
  `PWPoolReady` tag.  Allow re-adding instance when set `true` again.
* Reimplement max instance lifetime check.
* Implement a check on maximum completed tasks per instance.
* Stop outputting normal-status lines when examining instances.  Keep
  output to the bare minimum, unless there is some fault condition.
* Move the scheduled instance shutdown timer from the setup script into
  the instance maintenance script.  Add a check to confirm the sleep +
  shutdown process is running.
* Check and enforce a maximum amount of time `setup.sh` is allowed to
  run.
* Greatly simplify pool-listener service script.
* Simplify instance `setup.sh` script.
* Update utilization GNUplot command file to utilize details from
  `pw_lib.sh`.  Also extend the timespan of the graph.