### PR TITLE
[5.0.0] Fix truncating stdio magic devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ if [[ -n "$AUTOMATION_LIB_PATH" ]]; then
 else
     (
     echo "WARNING: It doesn't appear containers/automation common was installed."
-    ) > /dev/stderr
+    ) >> /dev/stderr
 fi
 
 ...do stuff...

--- a/bin/run_all_tests.sh
+++ b/bin/run_all_tests.sh
@@ -20,10 +20,10 @@ runner_script_filename="$(basename $0)"
 for test_subdir in $(find "$(realpath $(dirname $0)/../)" -type d -name test | sort -r); do
     test_runner_filepath="$test_subdir/$runner_script_filename"
     if [[ -x "$test_runner_filepath" ]] && [[ "$test_runner_filepath" != "$this_script_filepath" ]]; then
-        echo -e "\nExecuting $test_runner_filepath..." > /dev/stderr
+        echo -e "\nExecuting $test_runner_filepath..." >> /dev/stderr
         $test_runner_filepath
     else
-        echo -e "\nWARNING: Skipping $test_runner_filepath" > /dev/stderr
+        echo -e "\nWARNING: Skipping $test_runner_filepath" >> /dev/stderr
     fi
 done
 

--- a/build-push/bin/build-push.sh
+++ b/build-push/bin/build-push.sh
@@ -22,7 +22,7 @@ if [[ ! -r "$AUTOMATION_LIB_PATH/common_lib.sh" ]]; then
         echo "ERROR: Expecting \$AUTOMATION_LIB_PATH to contain the installation"
         echo "       directory path for the common automation tooling."
         echo "       Please refer to the README.md for installation instructions."
-    ) > /dev/stderr
+    ) >> /dev/stderr
     exit 2  # Verified by tests
 fi
 
@@ -295,7 +295,7 @@ stage_notice() {
         echo "############################################################"
         echo "$msg"
         echo "############################################################"
-    ) > /dev/stderr
+    ) >> /dev/stderr
 }
 
 BUILTIID=""    # populated with the image-id on successful build
@@ -446,7 +446,7 @@ push_images() {
 
 # Handle requested help first before anything else
 if grep -q -- '--help' <<<"$@"; then
-    echo "$E_USAGE" > /dev/stdout  # allow grep'ing
+    echo "$E_USAGE" >> /dev/stdout  # allow grep'ing
     exit 0
 fi
 

--- a/build-push/test/fake_buildah.sh
+++ b/build-push/test/fake_buildah.sh
@@ -38,6 +38,6 @@ elif [[ "$1" == "info" ]]; then
 elif [[ "$1" == "images" ]]; then
     echo '[{"names":["localhost/foo/bar:latest"]}]'
 else
-    echo "ERROR: Unexpected arg '$1' to fake_buildah.sh" > /dev/stderr
+    echo "ERROR: Unexpected arg '$1' to fake_buildah.sh" >> /dev/stderr
     exit 9
 fi

--- a/build-push/test/testbuilds.sh
+++ b/build-push/test/testbuilds.sh
@@ -23,7 +23,7 @@ test_cmd "Confirm skopeo is available" \
     0 "skopeo version .+" \
     skopeo --version
 
-PREPCMD='echo "SpecialErrorMessage:$REGSERVER" > /dev/stderr && exit 42'
+PREPCMD='echo "SpecialErrorMessage:$REGSERVER" >> /dev/stderr && exit 42'
 test_cmd "Confirm error output and exit(42) from --prepcmd" \
     42 "SpecialErrorMessage:localhost" \
     bash -c "$SUBJ_FILEPATH --nopush localhost/foo/bar $TEST_CONTEXT --prepcmd='$PREPCMD' 2>&1"

--- a/cirrus-ci_artifacts/cirrus-ci_artifacts
+++ b/cirrus-ci_artifacts/cirrus-ci_artifacts
@@ -16,7 +16,7 @@ if [[ -z "$AUTOMATION_LIB_PATH" ]]; then
     (
         echo "ERROR: Expecting \$AUTOMATION_LIB_PATH to be defined with the"
         echo "       installation directory of automation tooling."
-    ) > /dev/stderr
+    ) >> /dev/stderr
     exit 1
 fi
 

--- a/cirrus-ci_artifacts/test/test_cirrus-ci_artifacts.py
+++ b/cirrus-ci_artifacts/test/test_cirrus-ci_artifacts.py
@@ -160,6 +160,8 @@ class TestMain(unittest.TestCase):
         fake_stdout = StringIO()
         fake_stderr = StringIO()
         with redirect_stderr(fake_stderr), redirect_stdout(fake_stdout):
+            import warnings
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
             results = ccia.main(self.bid)
         self.assertEqual(fake_stderr.getvalue(), '')
         for line in fake_stdout.getvalue().splitlines():

--- a/cirrus-ci_retrospective/lib/cirrus-ci_retrospective.sh
+++ b/cirrus-ci_retrospective/lib/cirrus-ci_retrospective.sh
@@ -64,7 +64,7 @@ curl_post() {
         die "Expecting non-empty data argument"
 
     [[ -n "$token" ]] || \
-        dbg "### Warning: \$GITHUB_TOKEN is empty, performing unauthenticated query" > /dev/stderr
+        dbg "### Warning: \$GITHUB_TOKEN is empty, performing unauthenticated query" >> /dev/stderr
     # Don't expose secrets on any command-line
     local headers_tmpf
     local headers_tmpf=$(tmpfile headers)
@@ -81,7 +81,7 @@ EOF
     local curl_cmd="$CURL --silent --request POST --url $url --header @$headers_tmpf --data @$data_tmpf"
     dbg "### Executing '$curl_cmd'"
     local ret="0"
-    $curl_cmd > /dev/stdout || ret=$?
+    $curl_cmd >> /dev/stdout || ret=$?
 
     # Don't leave secrets lying around in files
     rm -f "$headers_tmpf" "$data_tmpf" &> /dev/null

--- a/common/bin/ooe.sh
+++ b/common/bin/ooe.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 SCRIPT_BASEDIR="$(basename $0)"
 
 badusage() {
-    echo "Incorrect usage: $SCRIPT_BASEDIR) <command> [options]" > /dev/stderr
+    echo "Incorrect usage: $SCRIPT_BASEDIR) <command> [options]" >> /dev/stderr
     echo "ERROR: $1"
     exit 121
 }

--- a/common/lib/anchors.sh
+++ b/common/lib/anchors.sh
@@ -28,7 +28,7 @@ automation_version() {
     if [[ -n "$_avcache" ]]; then
         echo "$_avcache"
     else
-        echo "Error determining version number" > /dev/stderr
+        echo "Error determining version number" >> /dev/stderr
         exit 1
     fi
 }

--- a/common/lib/console_output.sh
+++ b/common/lib/console_output.sh
@@ -48,13 +48,13 @@ _fmt_ctx() {
 
 # Print a highly-visible message to stderr.  Usage: warn <msg>
 warn() {
-    _fmt_ctx "$WARNING_MSG_PREFIX ${1:-no warning message given}" > /dev/stderr
+    _fmt_ctx "$WARNING_MSG_PREFIX ${1:-no warning message given}" >> /dev/stderr
 }
 
 # Same as warn() but exit non-zero or with given exit code
 # usage: die <msg> [exit-code]
 die() {
-    _fmt_ctx "$ERROR_MSG_PREFIX ${1:-no error message given}" > /dev/stderr
+    _fmt_ctx "$ERROR_MSG_PREFIX ${1:-no error message given}" >> /dev/stderr
     local exit_code=${2:-1}
     ((exit_code==0)) || \
         exit $exit_code
@@ -67,12 +67,12 @@ dbg() {
         (
         echo
         echo "$DEBUG_MSG_PREFIX ${1:-No debugging message given} ($shortest_source_path:${BASH_LINENO[0]} in ${FUNCNAME[1]}())"
-        ) > /dev/stderr
+        ) >> /dev/stderr
     fi
 }
 
 msg() {
-    echo "${1:-No message specified}" &> /dev/stderr
+    echo "${1:-No message specified}" &>> /dev/stderr
 }
 
 # Mimic set +x for a single command, along with calling location and line.
@@ -81,7 +81,7 @@ showrun() {
     # Tried using readarray, it broke tests for some reason, too lazy to investigate.
     # shellcheck disable=SC2207
     context=($(caller 0))
-    echo "+ $*  # ${context[2]}:${context[0]} in ${context[1]}()" > /dev/stderr
+    echo "+ $*  # ${context[2]}:${context[0]} in ${context[1]}()" >> /dev/stderr
     "$@"
 }
 

--- a/common/lib/platform.sh
+++ b/common/lib/platform.sh
@@ -45,7 +45,7 @@ passthrough_envars() {
 
     for envar in SECRET_ENV_RE PASSTHROUGH_ENV_EXACT PASSTHROUGH_ENV_ATSTART PASSTHROUGH_ENV_ANYWHERE passthrough_env_re; do
       if [[ -z "${!envar}" ]]; then
-        echo "Error: Required env. var. \$$envar is unset or empty in call to passthrough_envars()" > /dev/stderr
+        echo "Error: Required env. var. \$$envar is unset or empty in call to passthrough_envars()" >> /dev/stderr
         exit 1
       fi
     done

--- a/common/test/run_all_tests.sh
+++ b/common/test/run_all_tests.sh
@@ -6,6 +6,6 @@ set -e
 
 cd $(dirname $0)
 for testscript in test???-*.sh; do
-    echo -e "\nExecuting $testscript..." > /dev/stderr
+    echo -e "\nExecuting $testscript..." >> /dev/stderr
     ./$testscript
 done


### PR DESCRIPTION
Redirecting to `/dev/stderr` or `/dev/stdout` can have a normally unintended side-effect when the caller wishes to send either of those elsewhere (like an actual file).  Namely, it will truncate the file before writing.  This is almost never the expected behavior.  Update all redirects to magic devices to append instead.

N/B: These scripts are used far and wide.  On the off-chance some downstream caller has previously depended on this side-effect, I'm marking this commit as 'breaking' accordingly.