### PR TITLE
Fix timebomb test using wrong basis

### DIFF
--- a/common/test/testlib-platform.sh
+++ b/common/test/testlib-platform.sh
@@ -85,12 +85,12 @@ test_cmd "timebomb() function requires at least one argument" \
 TZ=UTC12 \
 test_cmd "timebomb() function ignores TZ envar and forces UTC" \
     0 "" \
-    timebomb $(date -d "+11 hours" +%Y%m%d)  # Careful, $TZ does apply to inline call!
+    timebomb $(TZ=UTC date -d "+11 hours" +%Y%m%d)
 
 TZ=UTC12 \
 test_cmd "timebomb() function ignores TZ and compares < UTC-forced current date" \
     1 "TIME BOMB EXPIRED" \
-    timebomb $(date +%Y%m%d)
+    timebomb $(TZ=UTC date +%Y%m%d)
 
 test_cmd "timebomb() alerts user when no description given" \
   1 "No reason given" \


### PR DESCRIPTION
The "timebomb() function ignores TZ envar and forces UTC" test started failing (triggering the bomb unintentionally).  Fixed by forcing the in-line date-calculation to be based on UTC (which the test was assuming previously).  Also updated the subsequent test similarly, for consistency.