### PR TITLE
Synchronize maintenance script changes

### DIFF
--- a/mac_pw_pool/Cron.sh
+++ b/mac_pw_pool/Cron.sh
@@ -9,19 +9,17 @@
 #
 # PATH=/home/shared/.local/bin:/home/shared/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
 #
-# # Ensure the latest code is being used (including maintenance script)
-# 59   4            * * * cd $HOME/devel/automation && git remote update && git reset --hard origin/main
-#
 # # Keep log from filling up disk & make sure webserver is running
-# 59   5            * * * $HOME/devel/automation/mac_pw_pool/nightly_maintenance.sh
+# # (5am UTC is during CI-activity lul)
+# 59   4    * * * $HOME/devel/automation/mac_pw_pool/nightly_maintenance.sh &>> $CRONLOG
 #
 # # PW Pool management (usage drop-off from 03:00-15:00 UTC)
 # POOLTOKEN=<from https://cirrus-ci.com/pool/1cf8c7f7d7db0b56aecd89759721d2e710778c523a8c91c7c3aaee5b15b48d05>
 # CRONLOG=/home/shared/devel/automation/mac_pw_pool/Cron.log
-# */5  0-3,15-23    * * * /home/shared/devel/automation/mac_pw_pool/Cron.sh &>> $CRONLOG
+# */5  *    * * * /home/shared/devel/automation/mac_pw_pool/Cron.sh &>> $CRONLOG
 
 # shellcheck disable=SC2154
-[ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -w 300 "$0" "$0" "$@" || :
+[ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -e -w 300 "$0" "$0" "$@" || :
 
 # shellcheck source=./pw_lib.sh
 source $(dirname "${BASH_SOURCE[0]}")/pw_lib.sh

--- a/mac_pw_pool/nightly_maintenance.sh
+++ b/mac_pw_pool/nightly_maintenance.sh
@@ -2,14 +2,64 @@
 
 set -euo pipefail
 
-CRONLOG=$HOME/devel/automation/mac_pw_pool/Cron.log
-KEEP_LINES=10000
-set -x
-tail -n $KEEP_LINES $CRONLOG > ${CRONLOG}.tmp && mv ${CRONLOG}.tmp $CRONLOG
+cd $(dirname "${BASH_SOURCE[0]}")
 
-# Ensure the utilization graph always runs the latest image
-podman run --replace -d --rm --name pw_pool_web \
-  -p 8080:80 --security-opt label=disable \
-  -v $HOME/devel/automation/mac_pw_pool/html:/usr/share/nginx/html:ro \
-  --pull=newer \
-  docker.io/library/nginx:latest
+SCRIPTNAME="$(basename ${BASH_SOURCE[0]})"
+WEB_IMG="docker.io/library/nginx:latest"
+CRONLOG="Cron.log"
+CRONSCRIPT="Cron.sh"
+KEEP_LINES=10000
+MAX_REPO_AGE_DAYS=21
+
+# Do not use, these are needed to control script execution.
+_CNTNAME=pw_pool_web
+_FLOCKER="${_FLOCKER:-notlocked}"
+_RESTARTED_SCRIPT="${_RESTARTED_SCRIPT:-0}"
+
+if [[ ! -r "$CRONLOG" ]] || [[ ! -r "$CRONSCRIPT" ]] || [[ ! -d "../.git" ]]; then
+  echo "ERROR: $SCRIPTNAME not executing from correct directory" >> /dev/stderr
+  exit 1
+fi
+
+relaunch_web_container() {
+  # Assume code has changed, restart container w/ latest image
+  (
+    set -x
+    podman run --replace --name "$_CNTNAME" -it --rm --pull=newer -p 8080:80 \
+      -v $HOME/devel/automation/mac_pw_pool/html:/usr/share/nginx/html:ro,Z \
+      $WEB_IMG
+  )
+  echo "$SCRIPTNAME restarted pw_poolweb container"
+}
+
+# Don't perform maintenance while $CRONSCRIPT is running
+[[ "${_FLOCKER}" != "$CRONSCRIPT" ]] && exec env _FLOCKER="$CRONSCRIPT" flock -e -w 300 "$CRONSCRIPT" "$0" "$@" || :
+echo "$SCRIPTNAME running at $(date -u -Iseconds)"
+
+if ! ((_RESTARTED_SCRIPT)); then
+  # Make sure the recent code is being used.
+  last_commit_date=$(git log -1 --format="%cI" --no-show-signature  HEAD)
+  last_s=$(date -d "$last_commit_date" +%s)
+  now_s=$(date -u +%s)
+  diff_s=$((now_s-last_s))
+
+  if [[ "$diff_s" -gt $(($MAX_REPO_AGE_DAYS*24*60*60)) ]]; then
+    git remote update && git reset --hard origin/main
+    # maintain the same flock
+    echo "$SCRIPTNAME updatedd code older than $MAX_REPO_AGE_DAYS days, restarting script..."
+    env _RESTARTED_SCRIPT=1 _FLOCKER=$_FLOCKER "$0" "$@"
+    exit $?  # all done
+  else
+    echo "$SCRIPTNAME code appears recent ($last_commit_date), yay!"
+  fi
+fi
+
+tail -n $KEEP_LINES $CRONLOG > ${CRONLOG}.tmp && mv ${CRONLOG}.tmp $CRONLOG
+echo "$SCRIPTNAME rotated log"
+
+# Always restart web-container when code changes, otherwise only if required
+if ((_RESTARTED_SCRIPT)); then
+  relaunch_web_container
+else
+  podman container exists "$_CNTNAME" || relaunch_web_container
+fi


### PR DESCRIPTION
Previously, the automation repo was updated by a cron job w/o regard to possibly, currently executing scripts.  This is bad.  Fix the situation by only updating the repo. while holding a `Cron.sh` lock, taking care to restart the graph-presenting webserver container as required.