### PR TITLE
Mac PW Pool: Stop indexing local disks

### DIFF
--- a/mac_pw_pool/setup.sh
+++ b/mac_pw_pool/setup.sh
@@ -137,6 +137,11 @@ if ! mount | grep -q "$PWUSER"; then
         df -h
     )
 
+    # Disk indexing is useless on a CI system, and creates un-deletable
+    # files whereever $TEMPDIR happens to be pointing.  Ignore any
+    # individual volume failures that have an unknown state.
+    sudo mdutil -a -i off || true
+
     # User likely has pre-existing system processes trying to use
     # the (now) over-mounted home directory.
     sudo pkill -u $PWUSER || true


### PR DESCRIPTION
There's no point of this operation on a CI machine, and it creates non-deletable files for every user on the system.  Stop it for all volumes, ignoring any failures.