### PR TITLE
Bump golang to version 1.21

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -123,13 +123,10 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
   // different distros and distro-versions, golang version consistency
   // is desireable across build outputs.  In golang 1.21 and later,
   // it's possible to pin the version in each project using the
-  // toolchain go.mod directive.  Prior to 1.21, for now, we do not
-  // want Renovate to propose updates which also trigger golang
-  // auto-updates. The only way to fully disable these auto-updates
-  // in renovate is through a forced static-version constraint. This
-  // is undesireable from a maintenance perspective, and hopefully
-  // temporarry. Ref: Upstream discussion https://github.com/golang/go/issues/65847
-  "constraints": {"go": "1.20"},
+  // toolchain go.mod directive.  This should be done to prevent
+  // unwanted auto-updates.
+  // Ref: Upstream discussion https://github.com/golang/go/issues/65847
+  "constraints": {"go": "1.21"},
 
   // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.
   // https://docs.renovatebot.com/configuration-options/#packagerules


### PR DESCRIPTION
Lots of module updates are arriving which require this version, unblock all repos that depend on it.