### PR TITLE
Fix build-push failing on empty push list 

### DIFF
--- a/build-push/bin/build-push.sh
+++ b/build-push/bin/build-push.sh
@@ -405,13 +405,15 @@ get_manifest_tags() {
     fi
 
     dbg "Image listing json: $result_json"
-    if [[ -n "$result_json" ]]; then
+    if [[ -n "$result_json" ]]; then  # N/B: value could be '[]'
         # Rely on the caller to handle an empty list, ignore items missing a name key.
         if ! fqin_names=$(jq -r '.[]? | .names[]?'<<<"$result_json"); then
             die "Error obtaining image names from '$FQIN' manifest-list search result:
 $result_json"
         fi
-        grep "$FQIN"<<<"$fqin_names" | sort
+        # Don't emit an empty newline when the list is empty
+        [[ -z "$fqin_names" ]] || \
+            sort <<< "$fqin_names"
     fi
 }
 
@@ -423,10 +425,10 @@ push_images() {
     # It's possible that --modcmd=* removed all images, make sure
     # this is known to the caller.
     if ! fqin_list=$(get_manifest_tags); then
-        die "Error retrieving set of manifest-list tags to push for '$FQIN'"
+        die "Retrieving set of manifest-list tags to push for '$FQIN'"
     fi
     if [[ -z "$fqin_list" ]]; then
-        die "No FQIN(s) to be pushed."
+        warn "No FQIN(s) to be pushed."
     fi
 
     if ((PUSH)); then

--- a/build-push/bin/build-push.sh
+++ b/build-push/bin/build-push.sh
@@ -228,7 +228,8 @@ parse_args() {
                     dbg "Grabbing Context parameter: '$arg'."
                     CONTEXT=$(realpath -e -P $arg || die_help "$E_CONTEXT '$arg'")
                 else
-                    # Properly handle any embedded special characters
+                    # Hack: Allow array addition to handle any embedded special characters
+                    # shellcheck disable=SC2207
                     BUILD_ARGS+=($(printf "%q" "$arg"))
                 fi
                 ;;
@@ -290,7 +291,7 @@ stage_notice() {
     # N/B: It would be nice/helpful to resolve any env. vars. in '$@'
     #      for display.  Unfortunately this is hard to do safely
     #      with (e.g.) eval echo "$@" :(
-    msg="$@"
+    msg="$*"
     (
         echo "############################################################"
         echo "$msg"
@@ -322,7 +323,7 @@ parallel_build() {
 
     # Keep user-specified BUILD_ARGS near the beginning so errors are easy to spot
     # Provide a copy of the output in case something goes wrong in a complex build
-    stage_notice "Executing build command: '$RUNTIME build ${BUILD_ARGS[@]} ${_args[@]}'"
+    stage_notice "Executing build command: '$RUNTIME build ${BUILD_ARGS[*]} ${_args[*]}'"
     "$RUNTIME" build "${BUILD_ARGS[@]}" "${_args[@]}"
 }
 
@@ -378,6 +379,8 @@ run_prepmod_cmd() {
     local kind="$1"
     shift
     dbg "Exporting variables '$_CMD_ENV'"
+    # The indirect export is intentional here
+    # shellcheck disable=SC2163
     export $_CMD_ENV
     stage_notice "Executing $kind-command: " "$@"
     bash -c "$@"

--- a/build-push/test/testbuilds.sh
+++ b/build-push/test/testbuilds.sh
@@ -90,15 +90,12 @@ test_cmd "Verify tagged manifest image digest matches the same in latest" \
 MODCMD='
 set -x;
 $RUNTIME images && \
-    $RUNTIME manifest rm containers-storage:$FQIN:latest && \
-    $RUNTIME manifest rm containers-storage:$FQIN:9.8.7-testing && \
+    $RUNTIME manifest rm $FQIN:latest && \
+    $RUNTIME manifest rm $FQIN:9.8.7-testing && \
     echo "AllGone";
 '
-# TODO: Test fails due to: https://github.com/containers/buildah/issues/3490
-# for now pretend it should exit(125) which will be caught when bug is fixed
-# - causing it to exit(0) as it should
-test_cmd "Verify --modcmd can execute a long string with substitutions" \
-    125 "AllGone" \
+test_cmd "Verify --modcmd can execute command string that removes all tags" \
+    0 "AllGone.*No FQIN.+to be pushed" \
     bash -c "A_DEBUG=1 $SUBJ_FILEPATH --modcmd='$MODCMD' localhost/foo/bar --nopush $TEST_CONTEXT 2>&1"
 
 test_cmd "Verify previous --modcmd removed the 'latest' tagged image" \

--- a/build-push/test/testbuilds.sh
+++ b/build-push/test/testbuilds.sh
@@ -4,7 +4,7 @@
 # Any/all other usage is virtually guaranteed to fail and/or cause
 # harm to the system.
 
-for varname in RUNTIME TEST_FQIN BUILDAH_USERNAME BUILDAH_PASSWORD; do
+for varname in RUNTIME SUBJ_FILEPATH TEST_CONTEXT TEST_SOURCE_DIRPATH TEST_FQIN BUILDAH_USERNAME BUILDAH_PASSWORD; do
     value=${!varname}
     if [[ -z "$value" ]]; then
         echo "ERROR: Required \$$varname variable is unset/empty."
@@ -13,6 +13,8 @@ for varname in RUNTIME TEST_FQIN BUILDAH_USERNAME BUILDAH_PASSWORD; do
 done
 unset value
 
+# RUNTIME is defined by caller
+# shellcheck disable=SC2154
 $RUNTIME --version
 test_cmd "Confirm $(basename $RUNTIME) is available" \
     0 "buildah version .+" \
@@ -24,6 +26,8 @@ test_cmd "Confirm skopeo is available" \
     skopeo --version
 
 PREPCMD='echo "SpecialErrorMessage:$REGSERVER" >> /dev/stderr && exit 42'
+# SUBJ_FILEPATH and TEST_CONTEXT are defined by caller
+# shellcheck disable=SC2154
 test_cmd "Confirm error output and exit(42) from --prepcmd" \
     42 "SpecialErrorMessage:localhost" \
     bash -c "$SUBJ_FILEPATH --nopush localhost/foo/bar $TEST_CONTEXT --prepcmd='$PREPCMD' 2>&1"
@@ -109,6 +113,8 @@ FAKE_VERSION=$RANDOM
 MODCMD="set -ex;
 \$RUNTIME tag \$FQIN:latest \$FQIN:$FAKE_VERSION;
 \$RUNTIME manifest rm \$FQIN:latest;"
+# TEST_FQIN and TEST_SOURCE_DIRPATH defined by caller
+# shellcheck disable=SC2154
 test_cmd "Verify e2e workflow w/ additional build-args" \
     0 "Pushing $TEST_FQIN:$FAKE_VERSION" \
     bash -c "env A_DEBUG=1 $SUBJ_FILEPATH \


### PR DESCRIPTION
Prior to https://github.com/containers/image_build/pull/23 the
automation using `build-push.sh` always pushed its images.  This
obscured a bug that occurs when `fqin_names` is an empty string in
`get_manifest_tags()`.  In this case, the `grep` command will exit
non-zero, causing `push_images()` to:

```
die "Error retrieving set of manifest-list tags to push for '$FQIN'"
```

Fix this by adding an empty-string check and removing the unnecessary
`grep`.  Also, `push_images()` change `die "No FQIN(s) to be pushed."`
into a warning, since the condition should not be considered fatal.