### PR TITLE
Never update golang toolchain

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -193,6 +193,13 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
       "allowedVersions": "!/v((1.0.0)|(1.0.1))$/"
     },
 
+    // Skip updating the go.mod toolchain directive, humans will manage this.
+    {
+      "matchCategories": ["golang"],
+      "matchDepTypes": ["toolchain"],
+      "enabled": false
+    },
+
     // Add CI:DOCS prefix to skip unnecessary tests for golangci updates in podman CI.
     {
       "matchPackageNames": ["golangci/golangci-lint"],


### PR DESCRIPTION
Fixes: #193

Despite restrictions on `go` directive updates by Renovate, it was still proposing updates to the `toolchain` directive.  In order to maintain consistency across all projects, this value needs to be managed manually.  Detect when Renovate is trying to update it and shut it down.

Ref: Upstream https://github.com/renovatebot/renovate PR 28476