### PR TITLE
PW Pool: Reduce task-to-task corruption risk

### DIFF
--- a/mac_pw_pool/pw_lib.sh
+++ b/mac_pw_pool/pw_lib.sh
@@ -42,7 +42,7 @@ CREATE_STAGGER_HOURS=2
 
 # Instance shutdown controls (assumes terminate-on-shutdown behavior)
 PW_MAX_HOURS=24  # Since successful configuration
-PW_MAX_TASKS=30  # Logged by listener (N/B: Can be manipulated by tasks!)
+PW_MAX_TASKS=12  # Logged by listener (N/B: Log can be manipulated by tasks!)
 
 # How long to wait for setup.sh to finish running (drop a .setup.done file)
 # before forcibly terminating.


### PR DESCRIPTION
Previously instances would shutdown and auto-terminate if the controlling VM's `SetupInstances.sh` examined the remote worker log and found >= `PW_MAX_TASKS` logged.  However after examining the production `Cron.log`, it was found that nowhere near this number of tasks is actually running during `PW_MAX_HOURS`.  Cut the value in half to lower the risk of one/more tasks corrupting processes or the filesystem for other tasks.

Note: Eyeball average tasks before timed auto-shutdown was about 7