### PR TITLE
Unconfigure golang indirect vulnerability support

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -57,16 +57,13 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
     // (last-match wins rule).
     "enabled": true,
 
-    // Indirect dependencies are disabled by default for the `gomod` manager.
-    // However, for vulnerability updates we may want them even if they break
-    // during renovate's automatic top-level `go mod tidy`.
-    "packageRules": [
-      {
-        "matchManagers": ["gomod"],
-        "matchDepTypes": ["indirect"],
-        "enabled": true
-      }
-    ]
+    // Note: As of 2024-06-25 indirect golang dependency handling is
+    // broken in Renovate, and disabled by default.  This affects
+    // vulnerabilityAlerts in that if the dep is 'indirect' no PR
+    // will ever open, it must be handled manually.  Attempting
+    // to enable indirect deps (for golang) in this section will
+    // not work, it will always be overriden by the global golang
+    // indirect dep. setting.
   },
 
   // On a busy repo, automatic-rebasing will swamp the CI system.


### PR DESCRIPTION
Discovered by log analysis, Renovate will initially setup a vulnerable golang indirect dep for immediate PR creation.  However, later on in its run, PR creation will be disabled by the global indirect-golang default setting (disabled).  Extensive review of `packageRules` configuration shows no way to filter based on vulnerability status. This would be the only conceivable way to override the default.

Fix this by replacing the misleading/useless config. section with a comment block indicating that indirect golang vulnerabilities must be handled by hand.