### PR TITLE
Simplify the new podman CI skips

### DIFF
--- a/cirrus-task-map/cirrus-task-map
+++ b/cirrus-task-map/cirrus-task-map
@@ -787,12 +787,11 @@ sub _draw_boxes {
         $only_if =~ s/[\s\n]+/ /g;
         $only_if =~ s/^\s+|\s+$//g;
 
-        if ($only_if =~ /CI:DOCS.*CI:BUILD/) {
-            $label .= "[SKIP: CI:BUILD]\\l[SKIP: CI:DOCS]\\l";
+        # 2024-06-18 Paul CI skips
+        if ($only_if =~ m{\$CIRRUS_PR\s+==\s+''\s+.*\$CIRRUS_CHANGE_TITLE.*CI:ALL.*changesInclude.*test}) {
+            $label .= "[SKIP if not needed]";
         }
-        elsif ($only_if =~ /CI:DOCS/) {
-            $label .= "[SKIP: CI:DOCS]\\l";
-        }
+
         # 2020-10 used in automation_images repo
         elsif ($only_if eq q{$CIRRUS_PR != ''}) {
             $label .= "[only if PR]";
@@ -878,30 +877,15 @@ sub _draw_boxes {
 
         my @reasons;
 
-        # 2024-06-18 Paul CI skips
-        if ($skip =~ s|\$CIRRUS_PR\s+!=\s+''\s+&&\s+\$CIRRUS_CHANGE_TITLE\s+!=~\s+'\.\*CI:ALL\.\*\'\s+&&\s+!changesInclude\('.cirrus.yml', 'Makefile', 'contrib/cirrus/\*\*', 'vendor/\*\*', 'hack/\*\*', 'version/rawversion/\*'\)\s+&&\s+||) {
-            if ($skip eq q{!changesInclude('test/system/**') && !(changesInclude('**/*.go', '**/*.c') && !changesIncludeOnly('test/**', 'pkg/machine/e2e/**'))}) {
-                push @reasons, "no system tests needed";
-            }
-            elsif ($skip eq q{!changesInclude('test/e2e/**', 'test/utils/**') && !(changesInclude('**/*.go', '**/*.c') && !changesIncludeOnly('test/**', 'pkg/machine/e2e/**'))}) {
-                push @reasons, "no e2e tests needed";
-            }
-            elsif ($skip eq q{!changesInclude('cmd/podman/machine/**', 'pkg/machine/**', '**/*machine*.go')}) {
-                push @reasons, "no machine-related changes";
-            }
-            elsif ($skip eq q{!changesInclude('**/*build*.go', 'test/buildah-bud/**')}) {
-                push @reasons, "no buildah-related changes";
-            }
-            else {
-                warn "$ME: Cannot grok skip '$skip'\n";
-            }
-        }
         # automation_images
-        elsif ($skip eq q{$CIRRUS_CHANGE_TITLE =~ '.*CI:DOCS.*' || $CIRRUS_CHANGE_TITLE =~ '.*CI:TOOLING.*'}) {
+        if ($skip eq q{$CIRRUS_CHANGE_TITLE =~ '.*CI:DOCS.*' || $CIRRUS_CHANGE_TITLE =~ '.*CI:TOOLING.*'}) {
             push @reasons, "CI:DOCS or CI:TOOLING";
         }
         elsif ($skip eq q{$CIRRUS_CHANGE_TITLE =~ '.*CI:DOCS.*'}) {
             push @reasons, "CI:DOCS";
+        }
+        elsif ($skip eq '$CI == $CI') {
+            push @reasons, "DISABLED MANUALLY";
         }
         elsif ($skip) {
             warn "$ME: unexpected skip '$skip'\n";


### PR DESCRIPTION
They are now under only_if, not skip. And there's really no need
for individual names, just say "SKIP if not needed"

Also, add handling for 'skip CI=CI', currently used in minikube

Signed-off-by: Ed Santiago <santiago@redhat.com>
