### PR TITLE
Mac PW Pool: Add testing helper script 

### DIFF
--- a/mac_pw_pool/AllocateTestDH.sh
+++ b/mac_pw_pool/AllocateTestDH.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+
+# This script is intended for use by humans to allocate a dedicated-host
+# and create an instance on it for testing purposes.  When executed,
+# it will create a temporary clone of the repository with the necessary
+# modifications to manipulate the test host.  It's the user's responsibility
+# to cleanup this directory after manually removing the instance (see below).
+#
+# **Note**: Due to Apple/Amazon restrictions on the removal of these
+# resources, cleanup must be done manually.  You will need to shutdown and
+# terminate the instance, then wait 24-hours before releasing the
+# dedicated-host.  The hosts cost money w/n an instance is running.
+#
+# The script assumes:
+#
+# * The current $USER value reflects your actual identity such that
+#   the test instance may be labeled appropriatly for auditing.
+# * The `aws` CLI tool is installed on $PATH.
+# * Appropriate `~/.aws/credentials` credentials are setup.
+# * The us-east-1 region is selected in `~/.aws/config`.
+# * The $POOLTOKEN env. var. is set to value available from
+#   https://cirrus-ci.com/pool/1cf8c7f7d7db0b56aecd89759721d2e710778c523a8c91c7c3aaee5b15b48d05
+# * The local ssh-agent is able to supply the appropriate private key (stored in BW).
+
+set -eo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source $(dirname ${BASH_SOURCE[0]})/pw_lib.sh
+
+# Support debugging all mac_pw_pool scripts or only this one
+I_DEBUG="${I_DEBUG:0}"
+if ((I_DEBUG)); then
+    X_DEBUG=1
+    warn "Debugging enabled."
+fi
+
+dbg "\$USER=$USER"
+
+[[ -n "$USER" ]] || \
+    die "The variable \$USER must not be empty"
+
+[[ -n "$POOLTOKEN" ]] || \
+    die "The variable \$POOLTOKEN must not be empty"
+
+INST_NAME="${USER}Testing"
+LIB_DIRNAME=$(realpath --relative-to=$REPO_DIRPATH $LIB_DIRPATH)
+# /tmp is usually a tmpfs, don't let an accidental reboot ruin
+# access to a test DH/instance for a developer.
+TMP_CLONE_DIRPATH="/var/tmp/${LIB_DIRNAME}_${INST_NAME}"
+
+dbg "\$TMP_CLONE_DIRPATH=$TMP_CLONE_DIRPATH"
+
+if [[ -d "$TMP_CLONE_DIRPATH" ]]; then
+    die "Found existing '$TMP_CLONE_DIRPATH', assuming in-use/relevant; If not, manual cleanup is required."
+fi
+
+msg "Creating temporary clone dir and transfering any uncommited files."
+
+git clone --no-local --no-hardlinks --depth 1 --single-branch --no-tags --quiet "file://$REPO_DIRPATH" "$TMP_CLONE_DIRPATH"
+declare -a uncommited_filepaths
+readarray -t uncommited_filepaths <<<$(
+    pushd "$REPO_DIRPATH" &> /dev/null
+    # Obtaining uncommited relative staged filepaths
+    git diff --name-only HEAD
+    # Obtaining uncommited relative unstaged filepaths
+    git ls-files . --exclude-standard --others
+    popd &> /dev/null
+)
+
+dbg "Copying \$uncommited_filepaths[*]=${uncommited_filepaths[*]}"
+
+for uncommited_file in "${uncommited_filepaths[@]}"; do
+    uncommited_file_src="$REPO_DIRPATH/$uncommited_file"
+    uncommited_file_dest="$TMP_CLONE_DIRPATH/$uncommited_file"
+    uncommited_file_dest_parent=$(dirname "$uncommited_file_dest")
+    #dbg "Working on uncommited file '$uncommited_file_src'"
+    if [[ -r "$uncommited_file_src" ]]; then
+        mkdir -p "$uncommited_file_dest_parent"
+        #dbg "$uncommited_file_src -> $uncommited_file_dest"
+        cp -a "$uncommited_file_src" "$uncommited_file_dest"
+    fi
+done
+
+declare -a modargs
+# Format: <pw_lib.sh var name> <new value> <old value>
+modargs=(
+    # Necessary to prevent in-production macs from trying to use testing instance
+    "DH_REQ_VAL          $INST_NAME     $DH_REQ_VAL"
+    # Necessary to make test dedicated host stand out when auditing the set in the console
+    "DH_PFX              $INST_NAME     $DH_PFX"
+    # The default launch template name includes $DH_PFX, ensure the production template name is used.
+    # N/B: The old/unmodified pw_lib.sh is still loaded for the running script
+    "TEMPLATE_NAME       $TEMPLATE_NAME Cirrus${DH_PFX}PWinstance"
+    # Permit developer to use instance for up to 3 days max (orphan vm cleaning process will nail it after that).
+    "PW_MAX_HOURS        72             $PW_MAX_HOURS"
+    # Permit developer to execute as many Cirrus-CI tasks as they want w/o automatic shutdown.
+    "PW_MAX_TASKS        9999           $PW_MAX_TASKS"
+)
+
+for modarg in "${modargs[@]}"; do
+    set -- $modarg # Convert the "tuple" into the param args $1 $2...
+    dbg "Modifying pw_lib.sh \$$1 definition to '$2' (was '$3')"
+    sed -i -r -e "s/^$1=.*/$1=\"$2\"/" "$TMP_CLONE_DIRPATH/$LIB_DIRNAME/pw_lib.sh"
+    # Ensure future script invocations use the new values
+    unset $1
+done
+
+cd "$TMP_CLONE_DIRPATH/$LIB_DIRNAME"
+source ./pw_lib.sh
+
+# Before going any further, make sure there isn't an existing
+# dedicated-host named ${INST_NAME}-0.  If there is, it can
+# be re-used instead of failing the script outright.
+existing_dh_json=$(mktemp -p "." dh_allocate_XXXXX.json)
+$AWS ec2 describe-hosts --filter "Name=tag:Name,Values=${INST_NAME}-0" --query 'Hosts[].HostId' > "$existing_dh_json"
+if grep -Fqx '[]' "$existing_dh_json"; then
+
+    msg "Creating the dedicated host '${INST_NAME}-0'"
+    declare dh_allocate_json
+    dh_allocate_json=$(mktemp -p "." dh_allocate_XXXXX.json)
+
+    declare -a awsargs
+    # Word-splitting of $AWS is desireable
+    # shellcheck disable=SC2206
+    awsargs=(
+        $AWS
+        ec2 allocate-hosts
+        --availability-zone us-east-1a
+        --instance-type mac2.metal
+        --auto-placement off
+        --host-recovery off
+        --host-maintenance off
+        --quantity 1
+        --tag-specifications
+        "ResourceType=dedicated-host,Tags=[{Key=Name,Value=${INST_NAME}-0},{Key=$DH_REQ_TAG,Value=$DH_REQ_VAL},{Key=PWPoolReady,Value=true},{Key=automation,Value=false}]"
+    )
+
+    # N/B: Apple/Amazon require min allocation time of 24hours!
+    dbg "Executing: ${awsargs[*]}"
+    "${awsargs[@]}" > "$dh_allocate_json" || \
+        die "Provisioning new dedicated host $INST_NAME failed.  Manual debugging & cleanup required."
+
+    dbg $(jq . "$dh_allocate_json")
+    dhid=$(jq -r -e '.HostIds[0]' "$dh_allocate_json")
+    [[ -n "$dhid" ]] || \
+        die "Obtaining DH ID of new host. Manual debugging & cleanup required."
+
+    # There's a small delay between allocating the dedicated host and LaunchInstances.sh
+    # being able to interact with it.  There's no sensible way to monitor for this state :(
+    sleep 3s
+else  # A dedicated host already exists
+    dhid=$(jq -r -e '.[0]' "$existing_dh_json")
+fi
+
+# Normally allocation is fairly instant, but not always.  Confirm we're able to actually
+# launch a mac instance onto the dedicated host.
+for ((attempt=1 ; attempt < 11 ; attempt++)); do
+    msg "Attempt #$attempt launching a new instance on dedicated host"
+    ./LaunchInstances.sh --force
+    if grep -E "^${INST_NAME}-0 i-" dh_status.txt; then
+        attempt=-1  # signal success
+        break
+    fi
+    sleep 1s
+done
+
+[[ "$attempt" -eq -1 ]] || \
+    die "Failed to use LaunchInstances.sh.  Manual debugging & cleanup required."
+
+# At this point the script could call SetupInstances.sh in another loop
+# but it takes about 20-minutes to complete.  Also, the developer may
+# not need it, they may simply want to ssh into the instance to poke
+# around.  i.e. they don't need to run any Cirrus-CI jobs on the test
+# instance.
+warn "---"
+warn "NOT copying/running setup.sh to new instance (in case manual activities are desired)."
+warn "---"
+
+w="PLEASE REMEMBER TO terminate instance, wait two hours, then
+remove the dedicated-host in the web console, or run
+'aws ec2 release-hosts --host-ids=$dhid'."
+
+msg "---"
+msg "Dropping you into a shell inside a temp. repo clone:
+($TMP_CLONE_DIRPATH/$LIB_DIRNAME)"
+msg "---"
+msg "Once it finishes booting (5m), you may use './InstanceSSH.sh ${INST_NAME}-0'
+to access it.  Otherwise to fully setup the instance for Cirrus-CI, you need
+to execute './SetupInstances.sh' repeatedly until the ${INST_NAME}-0 line in
+'pw_status.txt' includes the text 'complete alive'.  That process can take 20+
+minutes.  Once alive, you may then use Cirrus-CI to test against this specific
+instance with any 'persistent_worker' task having a label of
+'$DH_REQ_TAG=$DH_REQ_VAL' set."
+msg "---"
+warn "$w"
+
+export POOLTOKEN  # ensure availability in sub-shell
+bash -l
+
+warn "$w"

--- a/mac_pw_pool/Cron.sh
+++ b/mac_pw_pool/Cron.sh
@@ -53,8 +53,8 @@ timestamp=$(date -u -Iseconds -d \
                 awk '{print $4}'))
 pw_state=$(grep -E -v '^($|#+| +)' "$PWSTATE")
 n_workers=$(grep 'complete alive' <<<"$pw_state" | wc -l)
-n_tasks=$(awk 'BEGIN{B=0} /MacM1-[0-9]+ complete alive/{B+=$4} END{print B}' <<<"$pw_state")
-n_taskf=$(awk 'BEGIN{E=0} /MacM1-[0-9]+ complete alive/{E+=$5} END{print E}' <<<"$pw_state")
+n_tasks=$(awk "BEGIN{B=0} /${DH_PFX}-[0-9]+ complete alive/{B+=\$4} END{print B}" <<<"$pw_state")
+n_taskf=$(awk "BEGIN{E=0} /${DH_PFX}-[0-9]+ complete alive/{E+=\$5} END{print E}" <<<"$pw_state")
 printf "%s,%i,%i,%i\n" "$timestamp" "$n_workers" "$n_tasks" "$n_taskf" | tee -a "$uzn_file"
 
 # Prevent uncontrolled growth of utilization.csv.  Assume this script

--- a/mac_pw_pool/LaunchInstances.sh
+++ b/mac_pw_pool/LaunchInstances.sh
@@ -59,7 +59,7 @@ inst_failure() {
 }
 
 # Find dedicated hosts to operate on.
-dh_name_flt="Name=tag:Name,Values=MacM1-*"
+dh_name_flt="Name=tag:Name,Values=${DH_PFX}-*"
 dh_tag_flt="Name=tag:$DH_REQ_TAG,Values=$DH_REQ_VAL"
 dh_qry='Hosts[].{HostID:HostId, Name:[Tags[?Key==`Name`].Value][] | [0]}'
 dh_searchout="$TEMPDIR/hosts.output"  # JSON or error message
@@ -93,14 +93,14 @@ dcmpfmt="+%Y%m%d%H%M"  # date comparison format compatible with numeric 'test'
 # their launch timestamps.
 declare -a pw_filt
 pw_filts=(
-  'Name=tag:Name,Values=MacM1-*'
+  "Name=tag:Name,Values=${DH_PFX}-*"
   'Name=tag:PWPoolReady,Values=true'
   "Name=tag:$DH_REQ_TAG,Values=$DH_REQ_VAL"
   'Name=instance-state-name,Values=running'
 )
 pw_query='Reservations[].Instances[].LaunchTime'
 inst_lt_f=$TEMPDIR/inst_launch_times
-dbg "Obtaining launch times for all running MacM1-* instances"
+dbg "Obtaining launch times for all running ${DH_PFX}-* instances"
 dbg "$AWS ec2 describe-instances --filters '${pw_filts[*]}' --query '$pw_query' &> '$inst_lt_f'"
 if ! $AWS ec2 describe-instances --filters "${pw_filts[@]}" --query "$pw_query" &> "$inst_lt_f"; then
     die "Can not query instances:
@@ -231,7 +231,7 @@ for name_hostid in "${NAME2HOSTID[@]}"; do
     if ((launch_new)); then
         msg "Creating new $name instance on $name host."
         if ! $AWS ec2 run-instances \
-                  --launch-template LaunchTemplateName=CirrusMacM1PWinstance \
+                  --launch-template LaunchTemplateName=${TEMPLATE_NAME} \
                   --tag-specifications \
                   "ResourceType=instance,Tags=[{Key=Name,Value=$name},{Key=$DH_REQ_TAG,Value=$DH_REQ_VAL},{Key=PWPoolReady,Value=true},{Key=automation,Value=true}]" \
                   --placement "HostId=$hostid" &> "$instoutput"; then

--- a/mac_pw_pool/README.md
+++ b/mac_pw_pool/README.md
@@ -85,29 +85,11 @@ tag, which must correspond to the value indicated in `pw_lib.sh`
 and in the target repo `.cirrus.yml`.  To test script and/or
 CI changes:
 
-1. Using the AWS EC2 WebUI, allocate one or more dedicated hosts.
-   - Make sure there are no white space characters in the name.
-   - Set instance family to `mac2`
-   - Set instance type to `mac2.metal`
-   - Choose an Availability zone, `us-east-1a` preferred but it's not critical.
-   - Turn off `Instance auto-placement`, `Host recovery` and `Host maintenance`.
-   - Set the tags: `automation==false`, `PWPoolReady==true`, and
-     `purpose==<name>_testing` where `<name>` is your name.
-1. Temporarily edit `pw_lib.sh` (DO NOT PUSH THIS CHANGE) to update the
-   `DH_REQ_VAL` value to `<name>_testing`, same as you set in step 1.
-1. Obtain the current worker pool token by clicking the "show"
-   button on [the status
-   page](https://cirrus-ci.com/pool/1cf8c7f7d7db0b56aecd89759721d2e710778c523a8c91c7c3aaee5b15b48d05).
-   You must be logged in with a github account having admin access
-   to view this page.
 1. Make sure you have locally met all requirements spelled out in the
-   header-comment of `LaunchInstances.sh` and `SetupInstances.sh`.
-   Importantly, make sure the shared ssh key has been added to the
-   currently running agent.
-1. Repeatedly execute `LaunchInstances.sh`. It will update `dh_status.txt`
-   with any warnings/errors.  When all new Mac instance(s) are successfully
-   allocated, it will show lines includeing the host name,
-   an ID, and a datetime stamp.
+   header-comment of `AllocateTestDH.sh`.
+1. Execute `AllocateTestDH.sh`.  It will operate out of a temporary
+   clone of the repository to prevent pushing required test-modifications
+   upstream.
 1. Repeatedly execute `SetupInstances.sh`. It will update `pw_status.txt`
    with any warnings/errors.  When successful, lines will include
    the host name, "complete", and "alive" status strings.

--- a/mac_pw_pool/Utilization.gnuplot
+++ b/mac_pw_pool/Utilization.gnuplot
@@ -18,7 +18,8 @@ set xrange [(system("date -u -Iseconds -d '26 hours ago'")):(system("date -u -Is
 
 set ylabel "Workers Online"
 set ytics border nomirror numeric
-set yrange [0:(system("grep 'MacM1' dh_status.txt | wc -l") * 1.5)]
+# Not practical to lookup $DH_PFX from pw_lib.sh
+set yrange [0:(system("grep -E '^[a-zA-Z0-9]+-[0-9]' dh_status.txt | wc -l") * 1.5)]
 
 set y2label "Worker Utilization"
 set y2tics border nomirror numeric

--- a/mac_pw_pool/pw_lib.sh
+++ b/mac_pw_pool/pw_lib.sh
@@ -7,6 +7,7 @@
 SCRIPT_FILENAME=$(basename "$0")  # N/B: Caller's arg0, not this library file path.
 SCRIPT_DIRPATH=$(dirname "$0")
 LIB_DIRPATH=$(dirname "${BASH_SOURCE[0]}")
+REPO_DIRPATH=$(realpath "$LIB_DIRPATH/../")
 TEMPDIR=$(mktemp -d -p '' "${SCRIPT_FILENAME}_XXXXX.tmp")
 trap "rm -rf '$TEMPDIR'" EXIT
 

--- a/mac_pw_pool/pw_lib.sh
+++ b/mac_pw_pool/pw_lib.sh
@@ -10,6 +10,11 @@ LIB_DIRPATH=$(dirname "${BASH_SOURCE[0]}")
 TEMPDIR=$(mktemp -d -p '' "${SCRIPT_FILENAME}_XXXXX.tmp")
 trap "rm -rf '$TEMPDIR'" EXIT
 
+# Dedicated host name prefix; Actual name will have a "-<X>" (number) appended.
+# N/B: ${DH_PFX}-<X> _MUST_ match dedicated host names as listed in dh_status.txt
+# using the regex ^[a-zA-Z0-9]+-[0-9] (see Utilization.gnuplot)
+DH_PFX="MacM1"
+
 # Only manage dedicated hosts with the following tag & value
 DH_REQ_TAG="purpose"
 DH_REQ_VAL="prod"
@@ -50,7 +55,7 @@ SETUP_MAX_SECONDS=1200  # Typical time ~600seconds
 
 # Name of launch template. Current/default version will be used.
 # https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#LaunchTemplates:
-TEMPLATE_NAME="${TEMPLATE_NAME:-CirrusMacM1PWinstance}"
+TEMPLATE_NAME="${TEMPLATE_NAME:-Cirrus${DH_PFX}PWinstance}"
 
 # Path to scripts to copy/execute on Darwin instances
 SETUP_SCRIPT="$LIB_DIRPATH/setup.sh"


### PR DESCRIPTION
Previously a lot of intricate and painful steps were requred to setup a
Mac dedicated-host for testing.  Make this process easier with a script
that does most of the work.  Update documentation accordingly.