### PR TITLE
Fail loudly when ssh-agent not running

### DIFF
--- a/mac_pw_pool/SetupInstances.sh
+++ b/mac_pw_pool/SetupInstances.sh
@@ -104,6 +104,10 @@ fi
 [[ -r "$DHSTATE" ]] || \
     die "Can't read from state file: $DHSTATE"
 
+if [[ -z "$SSH_AUTH_SOCK" ]] || [[ -z "$SSH_AGENT_PID" ]]; then
+    die "Cannot access an ssh-agent.  Please run 'ssh-agent -s > /run/user/$UID/ssh-agent.env' and 'ssh-add /path/to/required/key'."
+fi
+
 declare -a _dhstate
 readarray -t _dhstate <<<$(grep -E -v '^($|#+| +)' "$DHSTATE" | sort)
 n_inst=0


### PR DESCRIPTION
The agent is required to keep the public key secure since the local and remote user has sudo access.