### PR TITLE
Fix build-push CI env setup failure

### DIFF
--- a/build-push/test/qemusetup.sh
+++ b/build-push/test/qemusetup.sh
@@ -4,22 +4,16 @@
 
 set -eo pipefail
 
+# shellcheck disable=SC2154
 if  [[ "$CIRRUS_CI" == "true" ]]; then
     # Cirrus-CI is setup (see .cirrus.yml) to run tests on CentOS
     # for simplicity, but it has no native qemu-user-static.  For
     # the benefit of CI testing, cheat and use whatever random
     # emulators are included in the container image.
 
-    # Workaround silly stupid hub rate-limiting
-    cat >> /etc/containers/registries.conf << EOF
-[[registry]]
-prefix="docker.io/library"
-location="mirror.gcr.io"
-EOF
-
     # N/B: THIS IS NOT SAFE FOR PRODUCTION USE!!!!!
     podman run --rm --privileged \
-        docker.io/multiarch/qemu-user-static:latest \
+        mirror.gcr.io/multiarch/qemu-user-static:latest \
         --reset -p yes
 elif [[ -x "/usr/bin/qemu-aarch64-static" ]]; then
     # TODO: Better way to determine if kernel already setup?


### PR DESCRIPTION
For whatever reason, the `registries.conf` alias setup is no-longer working and the docker rate-limiting is causing CI breakage.  Fix this by simplifying to pulling directly from the google proxy.