### PR TITLE
Fix possible max-tasks PW pool cascade failure

### DIFF
--- a/mac_pw_pool/pw_lib.sh
+++ b/mac_pw_pool/pw_lib.sh
@@ -48,11 +48,12 @@ CREATE_STAGGER_HOURS=2
 
 # Instance shutdown controls (assumes terminate-on-shutdown behavior)
 PW_MAX_HOURS=24  # Since successful configuration
-PW_MAX_TASKS=12  # Logged by listener (N/B: Log can be manipulated by tasks!)
+PW_MAX_TASKS=24  # Logged by listener (N/B: Log can be manipulated by tasks!)
+PW_MIN_ALIVE=3  # Bypass enforcement of $PW_MAX_TASKS if <= alive/operating workers
 
 # How long to wait for setup.sh to finish running (drop a .setup.done file)
 # before forcibly terminating.
-SETUP_MAX_SECONDS=1200  # Typical time ~600seconds
+SETUP_MAX_SECONDS=2400  # Typical time ~10 minutes, use 2x safety-factor.
 
 # Name of launch template. Current/default version will be used.
 # https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#LaunchTemplates:


### PR DESCRIPTION
Fixes: #219

For integrity and safety reasons, there are multiple guardrails in place to limit the potential damage of a rogue/broken/misconfigured worker instance may cause. One of these restrictions is a maximum limit on the number of tasks that a worker may execute. However, if the pool is experiencing extraordinary utilization, it's possible that a large number of workers could encounter this limit at/near the same time. Assuming the pool load remains high, this will then further shorten the lifetime of the remaining online instances.

Also:

* Double the limit on allowed tasks (12 was too small based on heavy utilization).
* Double the allowed setup time to account for network slowdowns.
* Show both the soft and hard uptime limits for each worker.
* Issue warning if worker exceeds soft uptime limit.