### PR TITLE
Register `golangci-lint` auto update for `c/storage` to renovate

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -106,6 +106,23 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
       // Podman's installer script will puke if there's a 'v' prefix, as represented
       // in upstream golangci/golangci-lint releases.
       "extractVersionTemplate": "v(?<version>.+)"
+    },
+
+    // For c/storage manage the golangci-lint version as
+    // referenced in their Makefile.
+    {
+      "customType": "regex",
+      "fileMatch": "^tests/tools/Makefile$",
+      // make ignores whitespace around the value, make renovate do the same.
+      "matchStrings": [
+        "GOLANGCI_LINT_VERSION\\s+:=\\s+(?<currentValue>.+)\\s*"
+      ],
+      "depNameTemplate": "golangci/golangci-lint",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver-coerced",
+      // Podman's installer script will puke if there's a 'v' prefix, as represented
+      // in upstream golangci/golangci-lint releases.
+      "extractVersionTemplate": "v(?<version>.+)"
     }
   ],
 


### PR DESCRIPTION
This PR registers an automatic update of `golangci-lint` for `c/storage` to renovate.

- https://github.com/containers/storage/pull/2063