### PR TITLE
feat: create generic renovate regex managers configurations

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,38 @@
+name: Renovate
+
+on:
+  pull_request:
+    paths:
+      - ".github/renovate.json"
+      - ".github/renovate.json5"
+      - "renovate.json"
+      - "renovate.json5"
+      - "renovate/*.json"
+      - "renovate/*.json5"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      RENOVATE_PRESETS_DIR: ./renovate/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
+        with:
+          node-version: latest
+
+      - name: Install Renovate CLI
+        run: npm install -g renovate
+
+      - name: Validate Renovate config
+        run: renovate-config-validator --strict
+
+      - name: Validate Renovate presets
+        run: |
+          for file in $(find $RENOVATE_PRESETS_DIR -type f -name '*.json' -o -name '*.json5'); do
+            echo "Validating $file"
+            renovate-config-validator --strict $file
+          done

--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -33,7 +33,10 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
     ":gitSignOff",
 
     // Always rebase dep. update PRs from `main` when PR is stale
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+
+    // Generic Regex Managers for updating git references and versions for files Renovate doesn't natively support
+    "github>containers/automation//renovate/generic-regex-managers"
   ],
 
   // The default setting is ambiguous, explicitly base schedules on UTC

--- a/renovate/generic-regex-managers.json5
+++ b/renovate/generic-regex-managers.json5
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "customManagers": [
+        {
+            // Searches through Containerfiles to find ARG and ENV variables associated with git references
+            // and updates them to the latest commit digest.
+            // The regex captures the dependency name, package name, git reference, versioning strategy,
+            // and current digest from the renovate directive.
+            // ref: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+            "customType": "regex",
+            "fileMatch": [
+                "Containerfile$"
+            ],
+            "matchStrings": [
+                "#\\s*renovate:\\s*datasource=git-refs\\sdepName=(?<depName>\\S+)\\s(?:packageName=(?<packageName>\\S+)\\s)?(?:gitRef=(?<currentValue>\\S+)\\s)?(?:versioning=(?<versioning>\\S+)\\s)?(?:extractVersion=\\S+\\s)?type=(?<type>digest)\\s(?:ARG|ENV)\\s.*?=(?<currentDigest>\\S+)"
+            ],
+            "datasourceTemplate": "git-refs",
+            "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+        },
+        {
+            // Searches through Containerfiles to find ARG and ENV variables associated with various datasources
+            // and updates them to the latest version.
+            // The regex captures the dependency name, package name, versioning strategy,
+            // and current version value from the renovate directive.
+            // ref: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+            "customType": "regex",
+            "fileMatch": [
+                "Containerfile$"
+            ],
+            "matchStrings": [
+                "#\\s*renovate:\\s*datasource=(?<datasource>.*?)\\sdepName=(?<depName>\\S+)\\s(?:packageName=(?<packageName>\\S+)\\s)?(?:versioning=(?<versioning>\\S+)\\s)?(?:extractVersion=\\S+\\s)?(?:ARG|ENV)\\s.*?=(?<currentValue>\\S+)"
+            ],
+            "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+        }
+    ]
+}


### PR DESCRIPTION
Closes #224 

This PR acts as a starting point, for a "platform-owned" series of Renovate rules to allow the various engineering teams to manage versions of packages in files not supported by Renovate.  I have rolled out a similar approach to my company, where we work a lot with ~~Docker~~Containerfiles, and it has proven to be a great approach, rather than each project implementing hacks to try and achieve the same.

Across various projects in this org, it would be good if the engineers have the option to manage versions outside files natively supported by Renovate.

One recent instance I came across was @ericcurtin wanted to pin whisper.cpp to a specific git hash [here](https://github.com/containers/ramalama/pull/49), however having that version follow the main branch.  For now, he has hardcoded the commit hash, and I assume will manually update it as and when the maintainers remember.

With this change, the Ramalama maintainers can simply change the configuration to store the Git commit sha as an ARG or ENV, and add a small portion of metadata above the declaration.  Renovate will then own management of this dependency version.

This will look something like:

```
...
# renovate: datasource=git-refs depName=ggerganov/whisper.cpp packageName=https://github.com/ggerganov/whisper.cpp gitRef=master versioning=loose type=digest
ARG WHISPER_CPP_MASTER_SHA=22fcd5fd110ba1ff592b4e23013d870831756259

RUN git clone https://github.com/ggerganov/whisper.cpp.git && \
    cd whisper.cpp && \
    git reset --hard ${WHISPER_CPP_MASTER_SHA} && \
    make -j $(nproc) && \
    mv main /usr/bin/whisper-main && \
    mv server /usr/bin/whisper-server && \
    cd / && \
    rm -rf whisper.cpp
```  

Renovate then creates PRs to update the version as it does with any other dependency.  You can see some examples of using [Git SHAs](https://github.com/p5/renovate-sandbox/pull/12) and [GitHub Releases](https://github.com/p5/renovate-sandbox/pull/11)

This has already been implemented over in [Universal Blue](https://github.com/ublue-os/packages/commit/c38c3a1c33030df989a94a89171a2890d59e4830) for managing versions inside our RPM spec files, and has allowed us to stay on top of dependency upgrades where Dependabot wouldn't.

===

This PR also adds a Renovate validation workflow to ensure the configuration (both the repo and shared presets) are valid before PRs are merged, and therefore before having the chance to break things.  Yes, this workflow could be made more intelligent, with caching or similar, however it doesn't seem Renovate configurations are updated often, so it's not really worth spending time implementing this.


Small note from the author:

<details>

Looking for a job :) 
If you know of any available roles for a remote / London-based Platform Engineer, please reach out to me on LinkedIn - https://www.linkedin.com/in/robert-sturla/

</details>