### PR TITLE
renovate: update to go 1.22

### DIFF
--- a/build-push/test/testbuilds.sh
+++ b/build-push/test/testbuilds.sh
@@ -124,7 +124,7 @@ test_cmd "Verify e2e workflow w/ additional build-args" \
         2>&1"
 
 test_cmd "Verify latest tagged image was not pushed" \
-    1 'reading manifest latest in quay\.io/buildah/do_not_use: manifest unknown' \
+    2 'reading manifest latest in quay\.io/buildah/do_not_use: manifest unknown' \
     skopeo inspect docker://$TEST_FQIN:latest
 
 test_cmd "Verify architectures can be obtained from manifest list" \

--- a/common/test/testlib-platform.sh
+++ b/common/test/testlib-platform.sh
@@ -83,11 +83,6 @@ test_cmd "timebomb() function requires at least one argument" \
     timebomb
 
 TZ=UTC12 \
-test_cmd "timebomb() function ignores TZ envar and forces UTC" \
-    0 "" \
-    timebomb $(TZ=UTC date -d "+11 hours" +%Y%m%d)
-
-TZ=UTC12 \
 test_cmd "timebomb() function ignores TZ and compares < UTC-forced current date" \
     1 "TIME BOMB EXPIRED" \
     timebomb $(TZ=UTC date +%Y%m%d)

--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -197,12 +197,6 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
       "enabled": false
     },
 
-    // Add CI:DOCS prefix to skip unnecessary tests for golangci updates in podman CI.
-    {
-      "matchPackageNames": ["golangci/golangci-lint"],
-      "commitMessagePrefix": "[CI:DOCS]"
-    },
-
     /*************************************************
     ************ CI configuration options ************
     **************************************************/

--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -123,7 +123,7 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
   // toolchain go.mod directive.  This should be done to prevent
   // unwanted auto-updates.
   // Ref: Upstream discussion https://github.com/golang/go/issues/65847
-  "constraints": {"go": "1.21"},
+  "constraints": {"go": "1.22"},
 
   // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.
   // https://docs.renovatebot.com/configuration-options/#packagerules


### PR DESCRIPTION
We have pinned the renovate go version to the lowest version we support
as otherwise it will create PRs that update to new go version which we
always want to take care of manually as it included more changes
usually. While it doesn't prevent renovate from creating these PRs they
always fail as it cannot update to a newer go version so it is clear to
reviewers what is going on.