### PR TITLE
Remove renovate cevich auto-assign

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
 
         podman run -it \
             -v ./.github/renovate.json5:/usr/src/app/renovate.json5:z \
-            docker.io/renovate/renovate:latest \
+            ghcr.io/renovatebot/renovate:latest \
             renovate-config-validator
      3. Commit.
 
@@ -42,6 +42,4 @@
   /*************************************************
    *** Repository-specific configuration options ***
    *************************************************/
-  // Don't leave dep. update. PRs "hanging", assign them to people.
-  "assignees": ["cevich"],
 }


### PR DESCRIPTION
Previously renovate auto-assigned all updates in this repo to cevich who's no longer on the team.  Fix this, and update the container FQIN comment to a non-docker-hub location (to avoid rate-limit restrictions).