### PR TITLE
renovate: update image update PR reviewers

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -221,7 +221,7 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
       "matchFileNames": [".cirrus.yml"],
       "groupName": "CI VM Image",
       // Somebody(s) need to check image update PRs as soon as they open.
-      "reviewers": ["cevich"],
+      "reviewers": ["Luap99", "edsantiago"],
       // Don't wait, roll out CI VM Updates immediately
       "schedule": ["at any time"]
     },


### PR DESCRIPTION
Chris no longer works on our team and has no time to review them. Add Ed and myself as reviewers for these PR (we already reviewed them anyway) so we get a notification for all PRs and do not miss them.