### PR TITLE
mac_pw_pool: add zstd

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -6,7 +6,7 @@ RUN microdnf update -y && \
             perl-Test perl-Test-Simple perl-Test-Differences \
             perl-YAML-LibYAML perl-FindBin \
         python3 python3-virtualenv python3-pip gcc python3-devel \
-        python3-flake8 python3-pep8-naming python3-flake8-docstrings python3-flake8-import-order python3-flake8-polyfill python3-mccabe python3-pep8-naming && \
+        python3-flake8 python3-pep8-naming python3-flake8-import-order python3-flake8-polyfill python3-mccabe python3-pep8-naming && \
     microdnf clean all && \
     rm -rf /var/cache/dnf
 # Required by perl

--- a/mac_pw_pool/setup.sh
+++ b/mac_pw_pool/setup.sh
@@ -98,6 +98,9 @@ if [[ ! -x /usr/local/bin/gvproxy ]]; then
         # Necessary for building podman|buildah|skopeo
         go go-md2man coreutils pkg-config pstree gpgme
 
+        # Necessary to compress the podman repo tar
+        zstd
+
         # Necessary for testing podman-machine
         vfkit
 


### PR DESCRIPTION
The new macos 15 base image does not contain it and the repo_prep in podman is failing because we need it to compress the tar with it.