### PR TITLE
Add tag field to cirrus-ci_retrospective

### DIFF
--- a/cirrus-ci_retrospective/bin/cirrus-ci_retrospective.sh
+++ b/cirrus-ci_retrospective/bin/cirrus-ci_retrospective.sh
@@ -117,7 +117,7 @@ do
             name
             status
             automaticReRun
-            build {id changeIdInRepo branch pullRequest status repository {
+            build {id changeIdInRepo branch pullRequest tag status repository {
                 owner name cloneUrl masterBranch
               }
             }


### PR DESCRIPTION
It's useful to know if the Cirrus CI task was triggered by a tag. Add it to the retro json.