### PR TITLE
Update to Go 1.24

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -123,7 +123,7 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
   // toolchain go.mod directive.  This should be done to prevent
   // unwanted auto-updates.
   // Ref: Upstream discussion https://github.com/golang/go/issues/65847
-  "constraints": {"go": "1.23"},
+  "constraints": {"go": "1.24"},
 
   // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.
   // https://docs.renovatebot.com/configuration-options/#packagerules


### PR DESCRIPTION
@Luap99 PTAL, this is required to let Renovate work after updating to Go 1.24, OTOH with https://github.com/containers/podman/pull/26874#issuecomment-3210127533, it might make sense to prefer Renovate working on the main Podman repo for a little while.