### PR TITLE
renovate: update to go 1.25

### DIFF
--- a/renovate/defaults.json5
+++ b/renovate/defaults.json5
@@ -123,7 +123,7 @@ and/or use the pre-commit hook: https://github.com/renovatebot/pre-commit-hooks
   // toolchain go.mod directive.  This should be done to prevent
   // unwanted auto-updates.
   // Ref: Upstream discussion https://github.com/golang/go/issues/65847
-  "constraints": {"go": "1.24"},
+  "constraints": {"go": "1.25"},
 
   // N/B: LAST MATCHING RULE WINS, match statems are ANDed together.
   // https://docs.renovatebot.com/configuration-options/#packagerules


### PR DESCRIPTION
We updated most repos to 1.25, only container-libs is not yet merged https://github.com/containers/container-libs/pull/692

I am not sure this change is needed, it seems renovate PRs are correctly created with go 1.25 despite this still being set to 1.24. Regardless lets be safe and bump this for now.